### PR TITLE
Tracking in reward

### DIFF
--- a/features/reward_features.py
+++ b/features/reward_features.py
@@ -265,20 +265,21 @@ class TrackingRewards(traits.HasTraits):
             super()._start_tracking_in()
             self.trigger_reward = False
             self.reward.off()
-            self.reward_start_frame = self.frame_index + self.tracking_reward_interval*self.fps
+            self.reward_start_frame = self.frame_index + self.tracking_reward_interval*self.fps # frame to start first reward
 
         def _while_tracking_in(self):
             super()._while_tracking_in()
             # Give reward for tracking in
             if self.frame_index == self.reward_start_frame and self.trigger_reward==False:
                 self.trigger_reward = True
-                self.reward_stop_frame = self.frame_index + self.tracking_reward_time*self.fps
+                self.reward_stop_frame = self.frame_index + self.tracking_reward_time*self.fps # frame to stop current reward
+                self.reward_start_frame = self.frame_index + self.tracking_reward_interval*self.fps # frame to start next reward
                 self.reward.on()
-                print('REWARD ON')
+                print('REWARD ON', self.frame_index/self.fps)
             if self.frame_index > self.reward_stop_frame and self.trigger_reward==True:        
                 self.trigger_reward = False
                 self.reward.off()
-                print('REWARD OFF')
+                print('REWARD OFF', self.frame_index/self.fps)
 
         def _start_tracking_out(self):
             super()._start_tracking_out()

--- a/features/reward_features.py
+++ b/features/reward_features.py
@@ -265,12 +265,14 @@ class TrackingRewards(traits.HasTraits):
             super()._start_tracking_in()
             self.trigger_reward = False
             self.reward.off()
-            self.reward_start_frame = self.frame_index + self.tracking_reward_interval*self.fps # frame to start first reward
+            self.reward_start_frame = self.frame_index + self.tracking_reward_interval*self.fps
+            self.reward_stop_frame = self.reward_start_frame + self.tracking_reward_time*self.fps
+            print('START TRACKING', self.reward_start_frame, self.reward_stop_frame)
 
         def _while_tracking_in(self):
             super()._while_tracking_in()
             # Give reward for tracking in
-            if self.frame_index == self.reward_start_frame and self.trigger_reward==False:
+            if self.frame_index > self.reward_start_frame and self.trigger_reward==False:
                 self.trigger_reward = True
                 self.reward_stop_frame = self.frame_index + self.tracking_reward_time*self.fps # frame to stop current reward
                 self.reward_start_frame = self.frame_index + self.tracking_reward_interval*self.fps # frame to start next reward

--- a/features/reward_features.py
+++ b/features/reward_features.py
@@ -265,22 +265,20 @@ class TrackingRewards(traits.HasTraits):
             super()._start_tracking_in()
             self.trigger_reward = False
             self.reward.off()
-            self.reward_start_time = 0
+            self.reward_start_frame = self.frame_index + self.tracking_reward_interval*self.fps
 
         def _while_tracking_in(self):
             super()._while_tracking_in()
             # Give reward for tracking in
-            curr_time = self.frame_index/self.fps
-            # print(curr_time, self.trigger_reward)
-            if curr_time % self.tracking_reward_interval==0 and self.trigger_reward==False:
+            if self.frame_index == self.reward_start_frame and self.trigger_reward==False:
                 self.trigger_reward = True
-                self.reward_start_time = curr_time
+                self.reward_stop_frame = self.frame_index + self.tracking_reward_time*self.fps
                 self.reward.on()
-                print('REWARD ON', curr_time)
-            if curr_time - self.reward_start_time > self.tracking_reward_time and self.trigger_reward==True:        
+                print('REWARD ON')
+            if self.frame_index > self.reward_stop_frame and self.trigger_reward==True:        
                 self.trigger_reward = False
                 self.reward.off()
-                print('REWARD OFF', curr_time)
+                print('REWARD OFF')
 
         def _start_tracking_out(self):
             super()._start_tracking_out()

--- a/features/reward_features.py
+++ b/features/reward_features.py
@@ -265,20 +265,20 @@ class TrackingRewards(traits.HasTraits):
             super()._start_tracking_in()
             self.trigger_reward = False
             self.reward.off()
-            self.reward_start_frame = self.frame_index + self.tracking_reward_interval*self.fps
-            self.reward_stop_frame = self.reward_start_frame + self.tracking_reward_time*self.fps
+            self.reward_start_frame = self.frame_index + self.tracking_reward_interval*self.fps # frame to start first reward
+            self.reward_stop_frame = self.reward_start_frame + self.tracking_reward_time*self.fps # frame to stop first reward
             print('START TRACKING', self.reward_start_frame, self.reward_stop_frame)
 
         def _while_tracking_in(self):
             super()._while_tracking_in()
             # Give reward for tracking in
-            if self.frame_index > self.reward_start_frame and self.trigger_reward==False:
+            if self.frame_index >= self.reward_start_frame and self.trigger_reward==False:
                 self.trigger_reward = True
                 self.reward_stop_frame = self.frame_index + self.tracking_reward_time*self.fps # frame to stop current reward
                 self.reward_start_frame = self.frame_index + self.tracking_reward_interval*self.fps # frame to start next reward
                 self.reward.on()
                 print('REWARD ON', self.frame_index/self.fps)
-            if self.frame_index > self.reward_stop_frame and self.trigger_reward==True:        
+            if self.frame_index >= self.reward_stop_frame and self.trigger_reward==True:        
                 self.trigger_reward = False
                 self.reward.off()
                 print('REWARD OFF', self.frame_index/self.fps)


### PR DESCRIPTION
The updated code keeps track of the reward in frames/cycles instead of time and is accurate for reward intervals that are a multiple of 1/fps, but works for all intervals. For example, if fps is 120Hz, you can accurately use reward intervals that are a multiple of .025s.