### PR TITLE
Tracking task

### DIFF
--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -77,6 +77,7 @@ class TargetTracking(Sequence):
         self.plant_position = []
         self.disturbance_trial = False
         self.repeat_freq_set = False
+        self.gen_index = -1
 
         if self.velocity_control:
             print('VELOCITY CONTROL')
@@ -88,8 +89,7 @@ class TargetTracking(Sequence):
     def _parse_next_trial(self):
         '''Get the required data from the generator'''
         # yield idx, pts, disturbance, dis_trajectory :
-        self.gen_indices, self.targs, self.disturbance_trial, self.disturbance_path = self.next_trial # targs and disturbance are same length
-        print(self.gen_indices)
+        self.gen_index, self.targs, self.disturbance_trial, self.disturbance_path = self.next_trial # targs and disturbance are same length
 
         self.targs = np.squeeze(self.targs,axis=0)
         self.disturbance_path = np.squeeze(self.disturbance_path)
@@ -110,10 +110,12 @@ class TargetTracking(Sequence):
             self.next_trial = next(self.gen)
             self._parse_next_trial()
 
+        print(self.gen_index)
+
         for i in range(len(self.disturbance_path)):
             # Update the data sinks with trial information --> bmi3d_trials
             self.trial_record['trial'] = self.calc_trial_num()
-            self.trial_record['index'] = self.gen_indices
+            self.trial_record['index'] = self.gen_index
             self.trial_record['target'] = self.targs[i+self.lookahead]
             self.trial_record['disturbance'] = self.disturbance_path[i]
             self.trial_record['is_disturbance'] = self.disturbance_trial
@@ -140,10 +142,12 @@ class TargetTracking(Sequence):
         pass
 
     def _start_wait_retry(self):
+        print(self.gen_index)
+
         for i in range(len(self.disturbance_path)):
             # Update the data sinks with trial information --> bmi3d_trials
             self.trial_record['trial'] = self.calc_trial_num()
-            self.trial_record['index'] = self.gen_indices
+            self.trial_record['index'] = self.gen_index
             self.trial_record['target'] = self.targs[i+self.lookahead]
             self.trial_record['disturbance'] = self.disturbance_path[i]
             self.trial_record['is_disturbance'] = self.disturbance_trial
@@ -423,7 +427,7 @@ class ScreenTargetTracking(TargetTracking, Window):
 
         # Update the trial index
         self.task_data['trial'] = self.calc_trial_num()
-        self.task_data['gen_idx'] = self.gen_indices[self.frame_index]
+        self.task_data['gen_idx'] = self.gen_index
         
         # Save the target position at each cycle. 
         if self.trial_timed_out:

--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -88,6 +88,7 @@ class TargetTracking(Sequence):
         '''Get the required data from the generator'''
         # yield idx, pts, disturbance, dis_trajectory :
         self.gen_indices, self.targs, self.disturbance_trial, self.disturbance_path = self.next_trial # targs and disturbance are same length
+        print(self.gen_indices)
 
         self.targs = np.squeeze(self.targs,axis=0)
         self.disturbance_path = np.squeeze(self.disturbance_path)
@@ -384,6 +385,7 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     def init(self):
         self.add_dtype('trial', 'u4', (1,))
+        self.add_dtype('gen_idx', 'u4', (1,))
         self.add_dtype('plant_visible', '?', (1,))
         self.add_dtype('current_target', 'f8', (3,))
         self.add_dtype('current_disturbance', 'f8', (3,)) # see task_data['manual_input'] for cursor position without added disturbance
@@ -408,6 +410,7 @@ class ScreenTargetTracking(TargetTracking, Window):
 
         # Update the trial index
         self.task_data['trial'] = self.calc_trial_num()
+        self.task_data['gen_idx'] = self.gen_indices[self.frame_index]
         
         # Save the target position at each cycle. 
         if self.trial_timed_out:

--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -402,7 +402,7 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     def init(self):
         self.add_dtype('trial', 'u4', (1,))
-        self.add_dtype('gen_idx', 'u4', (1,))
+        self.add_dtype('gen_idx', 'int', (1,)) # dtype needs to be able to represent -1
         self.add_dtype('plant_visible', '?', (1,))
         self.add_dtype('current_target', 'f8', (3,))
         self.add_dtype('current_disturbance', 'f8', (3,)) # see task_data['manual_input'] for cursor position without added disturbance
@@ -428,6 +428,7 @@ class ScreenTargetTracking(TargetTracking, Window):
         # Update the trial index
         self.task_data['trial'] = self.calc_trial_num()
         self.task_data['gen_idx'] = self.gen_index
+        # print(self.task_data['gen_idx'])
         
         # Save the target position at each cycle. 
         if self.trial_timed_out:

--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -76,6 +76,7 @@ class TargetTracking(Sequence):
         self.trial_timed_out = True # check if the trial is finished
         self.plant_position = []
         self.disturbance_trial = False
+        self.repeat_freq_set = False
 
         if self.velocity_control:
             print('VELOCITY CONTROL')
@@ -102,18 +103,21 @@ class TargetTracking(Sequence):
 
         self.targs = np.concatenate((lookahead, self.targs),axis=0) # (time_length*sample_rate+30,3) # targs and disturbance are no longer same length
 
+    def _start_wait(self):
+        # Call parent method to draw the next target capture sequence from the generator
+        super()._start_wait()
+        if self.repeat_freq_set:
+            self.next_trial = next(self.gen)
+            self._parse_next_trial()
+
         for i in range(len(self.disturbance_path)):
-            # Update the data sinks with trial information
+            # Update the data sinks with trial information --> bmi3d_trials
             self.trial_record['trial'] = self.calc_trial_num()
             self.trial_record['index'] = self.gen_indices
             self.trial_record['target'] = self.targs[i+self.lookahead]
             self.trial_record['disturbance'] = self.disturbance_path[i]
             self.trial_record['is_disturbance'] = self.disturbance_trial
             self.sinks.send("trials", self.trial_record)
-
-    def _start_wait(self):
-        # Call parent method to draw the next target capture sequence from the generator
-        super()._start_wait()
 
         # trial is not finished
         self.trial_timed_out = False
@@ -136,6 +140,15 @@ class TargetTracking(Sequence):
         pass
 
     def _start_wait_retry(self):
+        for i in range(len(self.disturbance_path)):
+            # Update the data sinks with trial information --> bmi3d_trials
+            self.trial_record['trial'] = self.calc_trial_num()
+            self.trial_record['index'] = self.gen_indices
+            self.trial_record['target'] = self.targs[i+self.lookahead]
+            self.trial_record['disturbance'] = self.disturbance_path[i]
+            self.trial_record['is_disturbance'] = self.disturbance_trial
+            self.sinks.send("trials", self.trial_record)
+
          # trial is not finished
         self.trial_timed_out = False
 
@@ -681,6 +694,9 @@ class ScreenTargetTracking(TargetTracking, Window):
         self.bar.hide()
         self.bar.reset()
 
+        # skip to next generated trial using same freq set
+        self.repeat_freq_set = True
+
     def _while_timeout_penalty(self):
         super()._while_timeout_penalty()
         # # Add disturbance
@@ -709,6 +725,9 @@ class ScreenTargetTracking(TargetTracking, Window):
         self.bar.hide()
         self.bar.reset()
 
+        # skip to next generated trial using same freq set
+        self.repeat_freq_set = True
+
     def _while_hold_penalty(self):
         super()._while_hold_penalty()
         # # Add disturbance
@@ -731,6 +750,9 @@ class ScreenTargetTracking(TargetTracking, Window):
         self.sync_event('OTHER_PENALTY')
         # Cue failed trial
         self.target.cue_trial_end_failure()
+
+        # skip to next generated trial using same freq set
+        self.repeat_freq_set = True
 
     def _while_tracking_out_penalty(self):
         super()._while_tracking_out_penalty()
@@ -762,6 +784,9 @@ class ScreenTargetTracking(TargetTracking, Window):
         # Cue successful trial
         self.target.cue_trial_end_success()
         self.reward_frame_index = 0
+
+        # use next generated trial using other freq set
+        self.repeat_freq_set = False
 
     def _while_reward(self):
         super()._while_reward()

--- a/features/reward_features.py
+++ b/features/reward_features.py
@@ -267,7 +267,7 @@ class TrackingRewards(traits.HasTraits):
             self.reward.off()
             self.reward_start_frame = self.frame_index + self.tracking_reward_interval*self.fps # frame to start first reward
             self.reward_stop_frame = self.reward_start_frame + self.tracking_reward_time*self.fps # frame to stop first reward
-            print('START TRACKING', self.reward_start_frame, self.reward_stop_frame)
+            # print('START TRACKING', self.reward_start_frame, self.reward_stop_frame)
 
         def _while_tracking_in(self):
             super()._while_tracking_in()
@@ -277,11 +277,11 @@ class TrackingRewards(traits.HasTraits):
                 self.reward_stop_frame = self.frame_index + self.tracking_reward_time*self.fps # frame to stop current reward
                 self.reward_start_frame = self.frame_index + self.tracking_reward_interval*self.fps # frame to start next reward
                 self.reward.on()
-                print('REWARD ON', self.frame_index/self.fps)
+                # print('REWARD ON', self.frame_index/self.fps)
             if self.frame_index >= self.reward_stop_frame and self.trigger_reward==True:        
                 self.trigger_reward = False
                 self.reward.off()
-                print('REWARD OFF', self.frame_index/self.fps)
+                # print('REWARD OFF', self.frame_index/self.fps)
 
         def _start_tracking_out(self):
             super()._start_tracking_out()


### PR DESCRIPTION
This code enforces trials to alternate between even and odd frequency components. After a penalty trial, the trial generator increments by 2 - this skips to the next trial with the same freq structure (either even or odd). Bmi3d will keep repeating trials with the same freq structure (but different phase shifts to the trajectories are still random) until a reward trial. After a reward trial, the trial generator increments by 1 like normal.