### PR TITLE
Tracking task

### DIFF
--- a/built_in_tasks/manualcontrolmultitasks.py
+++ b/built_in_tasks/manualcontrolmultitasks.py
@@ -27,7 +27,7 @@ rotations = dict(
         [0, 0, 0, 1]]
     ),
     xzy = np.array(
-        [[1, 0, 0, 0], 
+        [[1, 0, 0, 0],
         [0, 0, 1, 0], 
         [0, 1, 0, 0], 
         [0, 0, 0, 1]]
@@ -88,7 +88,9 @@ class ManualControlMixin(traits.HasTraits):
     rotation = traits.OptionsList(*rotations, desc="Control rotation matrix", bmi3d_input_options=list(rotations.keys()))
     scale = traits.Float(1.0, desc="Control scale factor")
     exp_rotation = traits.OptionsList(*exp_rotations, desc="Experimental rotation matrix", bmi3d_input_options=list(exp_rotations.keys()))
-    pertubation_rotation = traits.Float(0.0, desc="rotation in the x,y plane in degrees")
+    perturbation_rotation_y = traits.Float(0.0, desc="rotation about bmi3d y-axis in degrees")
+    perturbation_rotation_z = traits.Float(0.0, desc="rotation about bmi3d z-axis in degrees")
+    perturbation_rotation_x = traits.Float(0.0, desc="rotation about bmi3d x-axis in degrees")
     offset = traits.Array(value=[0,0,0], desc="Control offset")
     is_bmi_seed = True
 
@@ -142,10 +144,13 @@ class ManualControlMixin(traits.HasTraits):
             [0, 0, self.scale, 0], 
             [0, 0, 0, 1]]
         )
-        old = np.concatenate((np.reshape(coords, -1), [1]))
-        new = np.linalg.multi_dot((old, offset, scale, rotations[self.rotation], exp_rotations[self.exp_rotation]))
-        pertubation_rot = R.from_euler('y', self.pertubation_rotation, degrees=True)
-        return np.matmul(pertubation_rot.as_matrix(), new[0:3])
+        old = np.concatenate((np.reshape(coords, -1), [1])) # manual input (3,) plus offset term
+        new = np.linalg.multi_dot((old, offset, scale, rotations[self.rotation], exp_rotations[self.exp_rotation])) # screen coords (3,) plus offset term
+        perturb_rot_y = R.from_euler('y', self.perturbation_rotation_y, degrees=True)
+        perturb_rot_z = R.from_euler('z', self.perturbation_rotation_z, degrees=True)
+        perturb_rot_x = R.from_euler('x', self.perturbation_rotation_x, degrees=True)
+        return np.linalg.multi_dot((new[0:3], perturb_rot_y.as_matrix(), perturb_rot_z.as_matrix(), perturb_rot_x.as_matrix()))
+        #return np.matmul(perturb_rot_y.as_matrix(), new[0:3])
 
     def _get_manual_position(self):
         '''

--- a/built_in_tasks/manualcontrolmultitasks.py
+++ b/built_in_tasks/manualcontrolmultitasks.py
@@ -88,7 +88,7 @@ class ManualControlMixin(traits.HasTraits):
     rotation = traits.OptionsList(*rotations, desc="Control rotation matrix", bmi3d_input_options=list(rotations.keys()))
     scale = traits.Float(1.0, desc="Control scale factor")
     exp_rotation = traits.OptionsList(*exp_rotations, desc="Experimental rotation matrix", bmi3d_input_options=list(exp_rotations.keys()))
-    perturbation_rotation_y = traits.Float(0.0, desc="rotation about bmi3d y-axis in degrees")
+    pertubation_rotation = traits.Float(0.0, desc="rotation about bmi3d y-axis in degrees") # this is perturbation_rotation_y
     perturbation_rotation_z = traits.Float(0.0, desc="rotation about bmi3d z-axis in degrees")
     perturbation_rotation_x = traits.Float(0.0, desc="rotation about bmi3d x-axis in degrees")
     offset = traits.Array(value=[0,0,0], desc="Control offset")
@@ -146,11 +146,10 @@ class ManualControlMixin(traits.HasTraits):
         )
         old = np.concatenate((np.reshape(coords, -1), [1])) # manual input (3,) plus offset term
         new = np.linalg.multi_dot((old, offset, scale, rotations[self.rotation], exp_rotations[self.exp_rotation])) # screen coords (3,) plus offset term
-        perturb_rot_y = R.from_euler('y', self.perturbation_rotation_y, degrees=True)
+        pertubation_rot = R.from_euler('y', self.pertubation_rotation, degrees=True) # this is perturb_rot_y
         perturb_rot_z = R.from_euler('z', self.perturbation_rotation_z, degrees=True)
         perturb_rot_x = R.from_euler('x', self.perturbation_rotation_x, degrees=True)
-        return np.linalg.multi_dot((new[0:3], perturb_rot_y.as_matrix(), perturb_rot_z.as_matrix(), perturb_rot_x.as_matrix()))
-        #return np.matmul(perturb_rot_y.as_matrix(), new[0:3])
+        return np.linalg.multi_dot((new[0:3], pertubation_rot.as_matrix(), perturb_rot_z.as_matrix(), perturb_rot_x.as_matrix()))
 
     def _get_manual_position(self):
         '''

--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -494,7 +494,7 @@ class ScreenTargetTracking(TargetTracking, Window):
     #### STATE FUNCTIONS ####
     def _start_wait(self):
         super()._start_wait()
-        # print('WAIT')
+        print('WAIT')
 
         if self.calc_trial_num() == 0:
             # Instantiate the targets here so they don't show up in any states that might come before "wait" 
@@ -520,6 +520,12 @@ class ScreenTargetTracking(TargetTracking, Window):
         # Set up the next trajectory
         next_trajectory = np.array(np.squeeze(self.targs)[:,2])
         next_trajectory[:self.lookahead] = next_trajectory[self.lookahead]
+
+        if hasattr(self, 'trajectory'):
+            for model in self.trajectory.graphics_models:
+                self.remove_model(model)
+            del self.trajectory
+
         self.trajectory = VirtualCableTarget(target_radius=self.trajectory_radius, target_color=target_colors[self.trajectory_color], trajectory=next_trajectory)
 
         for model in self.trajectory.graphics_models:
@@ -568,6 +574,12 @@ class ScreenTargetTracking(TargetTracking, Window):
         # Set up the next trajectory
         next_trajectory = np.array(np.squeeze(self.targs)[:,2])
         next_trajectory[:self.lookahead] = next_trajectory[self.lookahead]
+
+        if hasattr(self, 'trajectory'):
+            for model in self.trajectory.graphics_models:
+                self.remove_model(model)
+            del self.trajectory
+
         self.trajectory = VirtualCableTarget(target_radius=self.trajectory_radius, target_color=target_colors[self.trajectory_color], trajectory=next_trajectory)
 
         for model in self.trajectory.graphics_models:

--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -56,6 +56,7 @@ class TargetTracking(Sequence):
     state = "wait"
     tries = 0 # Helper variable to keep track of the number of failed attempts at initiating a given trial
 
+    wait_time = traits.Float(1., desc="Length of time in wait state (inter-trial interval)")
     reward_time = traits.Float(.5, desc="Length of reward dispensation")
     timeout_time = traits.Float(10, desc="Time allowed to go between trajectories")
     timeout_penalty_time = traits.Float(1, desc="Length of penalty time for initiation timeout error")
@@ -274,7 +275,7 @@ class TargetTracking(Sequence):
             - a random delay
             - require some initiation action
         '''
-        return True
+        return time_in_state > self.wait_time
 
     def _test_timeout(self, time_in_state):
         return time_in_state > self.timeout_time or self.pause

--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -93,8 +93,8 @@ class TargetTracking(Sequence):
 
     def _parse_next_trial(self):
         '''Get the required data from the generator'''
-        # yield idx, pts, disturbance, dis_trajectory :
-        self.gen_index, self.targs, self.disturbance_trial, self.disturbance_path = self.next_trial # targs and disturbance are same length
+        # yield idx, pts, disturbance, dis_trajectory, sample_rate :
+        self.gen_index, self.targs, self.disturbance_trial, self.disturbance_path, self.sample_rate = self.next_trial # targs and disturbance are same length
 
         self.targs = np.squeeze(self.targs,axis=0)
         self.disturbance_path = np.squeeze(self.disturbance_path)
@@ -111,6 +111,9 @@ class TargetTracking(Sequence):
     def _start_wait(self):
         # Call parent method to draw the next target capture sequence from the generator
         super()._start_wait()
+        if self.sample_rate != self.fps:
+            raise ValueError('generator sample rate must equal FSM fps!')
+
         if self.repeat_freq_set:
             self.next_trial = next(self.gen)
             self._parse_next_trial()
@@ -1087,7 +1090,7 @@ class ScreenTargetTracking(TargetTracking, Window):
                 ref_trajectory[:,2] = trials['ref'][trial_id]
                 dis_trajectory[:,2] = trials['dis'][trial_id] # scale will determine lower limit of target size for perfect tracking
                 pts.append(ref_trajectory)
-                yield idx, pts, disturbance, dis_trajectory
+                yield idx, pts, disturbance, dis_trajectory, sample_rate
                 idx += 1
 
     @staticmethod
@@ -1112,7 +1115,7 @@ class ScreenTargetTracking(TargetTracking, Window):
                 ref_trajectory[:,2] = trials['ref'][trial_id]
                 dis_trajectory[:,2] = trials['dis'][trial_id] # scale will determine lower limit of target size for perfect tracking
                 pts.append(ref_trajectory)
-                yield idx, pts, disturbance, dis_trajectory
+                yield idx, pts, disturbance, dis_trajectory, sample_rate
                 idx += 1
     
     @staticmethod
@@ -1152,5 +1155,5 @@ class ScreenTargetTracking(TargetTracking, Window):
                 pts = []
                 trajectory[:,2] = 5*np.concatenate((sum_of_sins_path[0]*np.ones(buffer_space_bef),sum_of_sins_path,sum_of_sins_path[-1]*np.ones(buffer_space_aft)))
                 pts.append(trajectory)
-                yield idx, pts, disturbance, disturbance_path
+                yield idx, pts, disturbance, disturbance_path, None
                 idx += 1

--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -10,7 +10,6 @@ import math
 import traceback
 import random
 from collections import OrderedDict
-import datetime
 
 from riglib.experiment import traits, Sequence, FSMTable, StateTransitions
 from riglib.stereo_opengl import ik
@@ -118,8 +117,6 @@ class TargetTracking(Sequence):
 
         print(self.gen_index)
 
-        # now = datetime.datetime.now()
-        # print(now)
         self.trial_record['trial'] = self.calc_trial_num()
         self.trial_record['index'] = self.gen_index
         self.trial_record['is_disturbance'] = self.disturbance_trial
@@ -128,7 +125,6 @@ class TargetTracking(Sequence):
             self.trial_record['target'] = self.targs[i+self.lookahead]
             self.trial_record['disturbance'] = self.disturbance_path[i]
             self.sinks.send("trials", self.trial_record)
-        # print(datetime.datetime.now()-now)
 
         # trial is not finished
         self.trial_timed_out = False
@@ -153,13 +149,13 @@ class TargetTracking(Sequence):
     def _start_wait_retry(self):
         print(self.gen_index)
 
+        self.trial_record['trial'] = self.calc_trial_num()
+        self.trial_record['index'] = self.gen_index
+        self.trial_record['is_disturbance'] = self.disturbance_trial
         for i in range(len(self.disturbance_path)):
             # Update the data sinks with trial information --> bmi3d_trials
-            self.trial_record['trial'] = self.calc_trial_num()
-            self.trial_record['index'] = self.gen_index
             self.trial_record['target'] = self.targs[i+self.lookahead]
             self.trial_record['disturbance'] = self.disturbance_path[i]
-            self.trial_record['is_disturbance'] = self.disturbance_trial
             self.sinks.send("trials", self.trial_record)
 
          # trial is not finished
@@ -520,10 +516,7 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     #### STATE FUNCTIONS ####
     def _start_wait(self):
-        now = datetime.datetime.now()
-        # print(now)
         super()._start_wait()
-        # print(datetime.datetime.now()-now) # get longer
         print('WAIT')
         # self.in_end_state = False
 
@@ -564,7 +557,6 @@ class ScreenTargetTracking(TargetTracking, Window):
 
         self.target.hide()
         self.trajectory.hide()
-        print(datetime.datetime.now()-now) # gets longer
 
     def _while_wait(self):
         super()._while_wait()

--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -112,7 +112,7 @@ class TargetTracking(Sequence):
         # Call parent method to draw the next target capture sequence from the generator
         super()._start_wait()
         if self.sample_rate != self.fps:
-            raise ValueError('generator sample rate must equal FSM fps!')
+            print('WARNING: generator sample rate should equal FSM fps!')
 
         if self.repeat_freq_set:
             self.next_trial = next(self.gen)

--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -10,6 +10,7 @@ import math
 import traceback
 import random
 from collections import OrderedDict
+import datetime
 
 from riglib.experiment import traits, Sequence, FSMTable, StateTransitions
 from riglib.stereo_opengl import ik
@@ -113,14 +114,17 @@ class TargetTracking(Sequence):
 
         print(self.gen_index)
 
+        # now = datetime.datetime.now()
+        # print(now)
+        self.trial_record['trial'] = self.calc_trial_num()
+        self.trial_record['index'] = self.gen_index
+        self.trial_record['is_disturbance'] = self.disturbance_trial
         for i in range(len(self.disturbance_path)):
             # Update the data sinks with trial information --> bmi3d_trials
-            self.trial_record['trial'] = self.calc_trial_num()
-            self.trial_record['index'] = self.gen_index
             self.trial_record['target'] = self.targs[i+self.lookahead]
             self.trial_record['disturbance'] = self.disturbance_path[i]
-            self.trial_record['is_disturbance'] = self.disturbance_trial
             self.sinks.send("trials", self.trial_record)
+        # print(datetime.datetime.now()-now)
 
         # trial is not finished
         self.trial_timed_out = False
@@ -493,7 +497,10 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     #### STATE FUNCTIONS ####
     def _start_wait(self):
+        now = datetime.datetime.now()
+        # print(now)
         super()._start_wait()
+        # print(datetime.datetime.now()-now) # get longer
         print('WAIT')
 
         if self.calc_trial_num() == 0:
@@ -533,6 +540,7 @@ class ScreenTargetTracking(TargetTracking, Window):
 
         self.target.hide()
         self.trajectory.hide()
+        print(datetime.datetime.now()-now) # gets longer
 
     def _while_wait(self):
         super()._while_wait()

--- a/features/generator_features.py
+++ b/features/generator_features.py
@@ -173,6 +173,7 @@ class IncrementalRotation(traits.HasTraits):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.num_increments = int( (self.final_rotation_y-self.init_rotation_y) / self.delta_rotation_y+1 )
         self.rotations = dict(
             yzx = np.array(    # names come from rows (optitrack), but screen coords come from columns:
                 [[0, 1, 0, 0], # x goes into second column (y-coordinate, coming out of screen)
@@ -243,16 +244,20 @@ class IncrementalRotation(traits.HasTraits):
         super()._start_wait()
         num_deltas = int(self.num_trials_success / self.trials_per_increment)
         perturbation_rotation_y = self.init_rotation_y + self.delta_rotation_y*num_deltas
-        if perturbation_rotation_y > self.final_rotation_y:
+        if self.num_trials_success >= self.num_increments * self.trials_per_increment:
             perturbation_rotation_y = self.final_rotation_y
+            perturbation_rotation_z = self.final_rotation_z
+            perturbation_rotation_x = self.final_rotation_x
         print(perturbation_rotation_y)
 
     def _start_wait_retry(self):
         super()._start_wait_retry()
         num_deltas = int(self.num_trials_success / self.trials_per_increment)
         perturbation_rotation_y = self.init_rotation_y + self.delta_rotation_y*num_deltas
-        if perturbation_rotation_y > self.final_rotation_y:
+        if self.num_trials_success >= self.num_increments * self.trials_per_increment:
             perturbation_rotation_y = self.final_rotation_y
+            perturbation_rotation_z = self.final_rotation_z
+            perturbation_rotation_x = self.final_rotation_x
         print(perturbation_rotation_y)
 
     def _start_reward(self):
@@ -289,13 +294,9 @@ class IncrementalRotation(traits.HasTraits):
         perturbation_rotation_x = self.init_rotation_x + self.delta_rotation_x*num_deltas
 
         # stop incrementing once final perturbation rotation reached
-        if perturbation_rotation_y > self.final_rotation_y:
+        if self.num_trials_success >= self.num_increments * self.trials_per_increment:
             perturbation_rotation_y = self.final_rotation_y
-
-        if perturbation_rotation_z > self.final_rotation_z:
             perturbation_rotation_z = self.final_rotation_z
-
-        if perturbation_rotation_x > self.final_rotation_x:
             perturbation_rotation_x = self.final_rotation_x
 
         # calculate the 3D rotation matrices

--- a/features/generator_features.py
+++ b/features/generator_features.py
@@ -155,6 +155,7 @@ class IncrementalRotation(traits.HasTraits):
     '''
     Gradually change the perturbation rotation over trials
     '''
+    exclude_parent_traits = ['pertubation_rotation', 'perturbation_rotation_z', 'perturbation_rotation_x']
 
     init_rotation_y  = traits.Float(0.0, desc="initial rotation about bmi3d y-axis in degrees")
     final_rotation_y = traits.Float(0.0, desc="final rotation about bmi3d y-axis in degrees")
@@ -171,138 +172,50 @@ class IncrementalRotation(traits.HasTraits):
 
     trials_per_increment = traits.Int(1, desc="number of successful trials per rotation step")
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.num_increments = int( (self.final_rotation_y-self.init_rotation_y) / self.delta_rotation_y+1 )
-        self.rotations = dict(
-            yzx = np.array(    # names come from rows (optitrack), but screen coords come from columns:
-                [[0, 1, 0, 0], # x goes into second column (y-coordinate, coming out of screen)
-                [0, 0, 1, 0],  # y goes into third column (z-coordinate, up)
-                [1, 0, 0, 0],  # z goes into first column (x-coordinate, right)
-                [0, 0, 0, 1]]
-            ),
-            zyx = np.array(
-                [[0, 0, 1, 0], 
-                [0, 1, 0, 0], 
-                [1, 0, 0, 0], 
-                [0, 0, 0, 1]]
-            ),
-            xzy = np.array(
-                [[1, 0, 0, 0],
-                [0, 0, 1, 0], 
-                [0, 1, 0, 0], 
-                [0, 0, 0, 1]]
-            ),
-            xyz = np.identity(4),
-        )
-
-        self.exp_rotations = dict(
-            none = np.identity(4),
-            about_x_90 = np.array(
-                [[1, 0, 0, 0], 
-                [0, 0, 1, 0], 
-                [0, 1, 0, 0], 
-                [0, 0, 0, 1]]
-            ),
-            about_x_minus_90 = np.array(
-                [[1, 0, 0, 0], 
-                [0, 0, -1, 0], 
-                [0, 1, 0, 0], 
-                [0, 0, 0, 1]]
-            ),
-            oop_xy_45 = np.array(
-                [[ 0.707,  0.5  ,  0.5  , 0.],
-                [ 0.   ,  0.707, -0.707, 0.],
-                [-0.707,  0.5  ,  0.5  , 0.],
-                [ 0.,     0.   ,  0.,    1.]]
-            ),
-            oop_xy_minus_45 = np.array(
-                [[ 0.707,  0.5  , -0.5  , 0.],
-                [ 0.   ,  0.707,  0.707, 0.],
-                [ 0.707, -0.5  ,  0.5  , 0.],
-                [ 0.,     0.   ,  0.,    1.]]
-            ),
-            oop_xy_20 = np.array(
-                [[ 0.94 ,  0.117,  0.321, 0.],
-                [-0.   ,  0.94 , -0.342, 0.],
-                [-0.342,  0.321,  0.883, 0.],
-                [ 0.,     0.   ,  0.,    1.]]
-            ),
-            oop_xy_minus_20 = np.array(
-                [[ 0.94 ,  0.117, -0.321, 0.],
-                [-0.   ,  0.94 ,  0.342, 0.],
-                [ 0.342, -0.321,  0.883, 0.],
-                [ 0.,     0.   ,  0.,    1.]]
-            )
-        )
-
     def init(self):    
         super().init()
         self.num_trials_success = 0
+        self.num_increments = int( (self.final_rotation_y-self.init_rotation_y) / self.delta_rotation_y+1 )
+        self.pertubation_rotation = self.init_rotation_y
+        self.perturbation_rotation_z = self.init_rotation_z
+        self.perturbation_rotation_x = self.init_rotation_x
 
     def _start_wait(self):
         super()._start_wait()
-        num_deltas = int(self.num_trials_success / self.trials_per_increment)
-        perturbation_rotation_y = self.init_rotation_y + self.delta_rotation_y*num_deltas
-        if self.num_trials_success >= self.num_increments * self.trials_per_increment:
-            perturbation_rotation_y = self.final_rotation_y
-            perturbation_rotation_z = self.final_rotation_z
-            perturbation_rotation_x = self.final_rotation_x
-        print(perturbation_rotation_y)
-
-    def _start_wait_retry(self):
-        super()._start_wait_retry()
-        num_deltas = int(self.num_trials_success / self.trials_per_increment)
-        perturbation_rotation_y = self.init_rotation_y + self.delta_rotation_y*num_deltas
-        if self.num_trials_success >= self.num_increments * self.trials_per_increment:
-            perturbation_rotation_y = self.final_rotation_y
-            perturbation_rotation_z = self.final_rotation_z
-            perturbation_rotation_x = self.final_rotation_x
-        print(perturbation_rotation_y)
-
-    def _start_reward(self):
-        super()._start_reward()
-        self.num_trials_success += 1
-         
-    def _transform_coords(self, coords):
-        ''' 
-        Returns transformed coordinates based on rotation, offset, and scale traits
-        '''
-        offset = np.array(
-            [[1, 0, 0, 0], 
-            [0, 1, 0, 0], 
-            [0, 0, 1, 0], 
-            [self.offset[0], self.offset[1], self.offset[2], 1]]
-        )
-        scale = np.array(
-            [[self.scale, 0, 0, 0], 
-            [0, self.scale, 0, 0], 
-            [0, 0, self.scale, 0], 
-            [0, 0, 0, 1]]
-        )
-        
-        # transform raw input coords into screen coords
-        old = np.concatenate((np.reshape(coords, -1), [1])) # manual input (3,) plus offset term
-        new = np.linalg.multi_dot((old, offset, scale, self.rotations[self.rotation], self.exp_rotations[self.exp_rotation])) # screen coords (3,) plus offset term
-
         # determine the current rotation step
         num_deltas = int(self.num_trials_success / self.trials_per_increment)
 
         # increment the current perturbation rotation by delta
-        perturbation_rotation_y = self.init_rotation_y + self.delta_rotation_y*num_deltas
-        perturbation_rotation_z = self.init_rotation_z + self.delta_rotation_z*num_deltas
-        perturbation_rotation_x = self.init_rotation_x + self.delta_rotation_x*num_deltas
+        self.pertubation_rotation = self.init_rotation_y + self.delta_rotation_y*num_deltas
+        self.perturbation_rotation_z = self.init_rotation_z + self.delta_rotation_z*num_deltas
+        self.perturbation_rotation_x = self.init_rotation_x + self.delta_rotation_x*num_deltas
 
         # stop incrementing once final perturbation rotation reached
         if self.num_trials_success >= self.num_increments * self.trials_per_increment:
-            perturbation_rotation_y = self.final_rotation_y
-            perturbation_rotation_z = self.final_rotation_z
-            perturbation_rotation_x = self.final_rotation_x
+            self.pertubation_rotation = self.final_rotation_y
+            self.perturbation_rotation_z = self.final_rotation_z
+            self.perturbation_rotation_x = self.final_rotation_x
+        
+        print(self.pertubation_rotation)
 
-        # calculate the 3D rotation matrices
-        perturb_rot_y = R.from_euler('y', perturbation_rotation_y, degrees=True)
-        perturb_rot_z = R.from_euler('z', perturbation_rotation_z, degrees=True)
-        perturb_rot_x = R.from_euler('x', perturbation_rotation_x, degrees=True)
+    def _start_wait_retry(self):
+        super()._start_wait_retry()
+        # determine the current rotation step
+        num_deltas = int(self.num_trials_success / self.trials_per_increment)
 
-        # apply the 3D rotation matrices one-by-one to the screen coords
-        return np.linalg.multi_dot((new[0:3], perturb_rot_y.as_matrix(), perturb_rot_z.as_matrix(), perturb_rot_x.as_matrix()))
+        # increment the current perturbation rotation by delta
+        self.pertubation_rotation = self.init_rotation_y + self.delta_rotation_y*num_deltas
+        self.perturbation_rotation_z = self.init_rotation_z + self.delta_rotation_z*num_deltas
+        self.perturbation_rotation_x = self.init_rotation_x + self.delta_rotation_x*num_deltas
+
+        # stop incrementing once final perturbation rotation reached
+        if self.num_trials_success >= self.num_increments * self.trials_per_increment:
+            self.pertubation_rotation = self.final_rotation_y
+            self.perturbation_rotation_z = self.final_rotation_z
+            self.perturbation_rotation_x = self.final_rotation_x
+        
+        print(self.pertubation_rotation)
+
+    def _start_reward(self):
+        super()._start_reward()
+        self.num_trials_success += 1


### PR DESCRIPTION
This code makes two changes:
1. Adds feature to make perturbation rotations around the other two axes (z and x). Previously only perturbation rotations around the y axis (corresponding to rotations in the x,y plane of the screen) was possible.
2. Move function that calculates trial number outside a for loop within the wait states of tracking task. This prevents task from spending increasingly more time in the wait state (which makes screen freeze between trials) as trials accumulate. Only affects tracking task.