### PR TITLE
fixing dual laser stimulation

### DIFF
--- a/built_in_tasks/othertasks.py
+++ b/built_in_tasks/othertasks.py
@@ -75,7 +75,6 @@ class LaserConditions(Conditions):
 
     sequence_generators = ['single_laser_pulse', 'single_laser_square_wave', 'dual_laser_square_wave']
     exclude_parent_traits = ['trial_time']
-    stimulation_site = traits.String("", desc="Where was the laser stimulation?")
 
     def __init__(self, *args, **kwargs):
         self.laser_threads = []

--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -93,6 +93,9 @@ class TargetTracking(Sequence):
 
     def _parse_next_trial(self):
         '''Get the required data from the generator'''
+        if self.state is None:
+            return
+        
         # yield idx, pts, disturbance, dis_trajectory, sample_rate :
         self.gen_index, self.targs, self.disturbance_trial, self.disturbance_path, self.sample_rate = self.next_trial # targs and disturbance are same length
 

--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -93,9 +93,6 @@ class TargetTracking(Sequence):
 
     def _parse_next_trial(self):
         '''Get the required data from the generator'''
-        if self.state is None:
-            return
-        
         # yield idx, pts, disturbance, dis_trajectory, sample_rate :
         self.gen_index, self.targs, self.disturbance_trial, self.disturbance_path, self.sample_rate = self.next_trial # targs and disturbance are same length
 

--- a/db/dbfunctions.py
+++ b/db/dbfunctions.py
@@ -1335,7 +1335,8 @@ def get_rawfiles_for_taskentry(e, system_subfolders=None):
         if df.system.name == 'optitrack' or df.system.name == 'e3v':
             path = os.path.normpath(df.path)
             parts = path.split(os.sep)
-            filepath = os.path.join(*parts[1:])
+            if len(parts) > 1:
+                filepath = os.path.join(*parts[1:])
             filepath = filepath.replace(':', '_')
         else:
             filepath = os.path.basename(df.path)

--- a/db/tracker/models.py
+++ b/db/tracker/models.py
@@ -700,6 +700,12 @@ class TaskEntry(models.Model):
         data = Parameters(self.metadata).params
         return data
 
+    @property
+    def sequence_params(self):
+        from .json_param import Parameters
+        data = Parameters(self.sequence.params).params
+        return data
+
     @staticmethod
     def get_default_metadata():
         subject = {

--- a/db/tracker/models.py
+++ b/db/tracker/models.py
@@ -1138,7 +1138,7 @@ class TaskEntry(models.Model):
         hdf['/'].attrs["session"] = self.session
         if self.sequence is not None:
             hdf['/'].attrs["sequence"] = self.sequence.name
-            hdf['/'].attrs["sequence_params"] = self.sequence_params
+            hdf['/'].attrs["sequence_params"] = self.sequence.params
             hdf['/'].attrs["generator"] = self.sequence.generator.name
             hdf['/'].attrs["generator_params"] = self.sequence.generator.params
         hdf['/'].attrs["report"] = self.report

--- a/db/tracker/models.py
+++ b/db/tracker/models.py
@@ -1135,7 +1135,7 @@ class TaskEntry(models.Model):
         hdf['/'].attrs["date"] = str(self.date)
         if self.sequence is not None:
             hdf['/'].attrs["sequence"] = self.sequence.name
-            hdf['/'].attrs["sequence_params"] = self.sequence.params
+            hdf['/'].attrs["sequence_params"] = self.sequence_params
             hdf['/'].attrs["generator"] = self.sequence.generator.name
             hdf['/'].attrs["generator_params"] = self.sequence.generator.params
         hdf['/'].attrs["report"] = self.report

--- a/features/laser_features.py
+++ b/features/laser_features.py
@@ -37,6 +37,9 @@ class QwalorLaser(traits.HasTraits):
     qwalor_trigger_dch = traits.Int(9, desc="Digital channel (0-index) recording laser trigger")
     qwalor_sensor_ach = traits.Int(16, desc="Analog channel (0-index) recording laser power")
     stimulation_site = traits.String("", desc="Where was the laser stimulation?")
+    stimulation_channel_mapping_file = traits.String("", desc="Name of channel mapping excel file")
+    stimulation_chamber = traits.String("", desc="Name of the stimulation chamber (e.g. LM1)")
+    stimulation_drive_type = traits.String("", desc="Type of stimulation drive (e.g. Opto32)")
 
     hidden_traits = ['qwalor_sensor_ach']
 
@@ -94,6 +97,9 @@ class MultiQwalorLaser(traits.HasTraits):
     stimulation_site_ch2 = traits.String("", desc="Where was the ch2 laser stimulation?")
     stimulation_site_ch3 = traits.String("", desc="Where was the ch3 laser stimulation?")
     stimulation_site_ch4 = traits.String("", desc="Where was the ch4 laser stimulation?")
+    stimulation_channel_mapping_file = traits.String("", desc="Name of channel mapping excel file")
+    stimulation_chamber = traits.String("", desc="Name of the stimulation chamber (e.g. LM1)")
+    stimulation_drive_type = traits.String("", desc="Type of stimulation drive (e.g. Opto32)")
 
     hidden_traits = ['qwalor_ch1_sensor_ach', 'qwalor_ch2_sensor_ach', 'qwalor_ch3_sensor_ach', 'qwalor_ch4_sensor_ach',
                      'qwalor_ch1_trigger_dch', 'qwalor_ch2_trigger_dch', 'qwalor_ch3_trigger_dch', 'qwalor_ch4_trigger_dch']

--- a/riglib/experiment/experiment.py
+++ b/riglib/experiment/experiment.py
@@ -802,11 +802,11 @@ class Sequence(LogExperiment):
 
         try:
             self.next_trial = next(self.gen)
-            self._parse_next_trial() # KP changed 10/26/22
+            # self._parse_next_trial() # KP changed 10/26/22
         except StopIteration:
             self.end_task()
 
-        # self._parse_next_trial()
+        self._parse_next_trial()
 
     def _parse_next_trial(self):
         '''

--- a/tests/test_qwalor_laser.py
+++ b/tests/test_qwalor_laser.py
@@ -56,21 +56,18 @@ class LaserTests(unittest.TestCase):
         laser1 = qwalor_laser.QwalorLaserSerial(2)
         laser1.port = laser1.trigger_pin
         laser1.name = 'qwalor_laser_ch2'
-        laser1.set_mode(mode)
-        laser1.set_freq(freq)
-        laser1.set_power(1)
         print("laser 1 configured")
 
         laser2 = qwalor_laser.QwalorLaserSerial(4)
         laser2.port = laser2.trigger_pin
         laser2.name = 'qwalor_laser_ch4'
-        laser2.set_mode(mode)
-        laser2.set_freq(freq)
-        laser2.set_power(1)
         print("laser 2 configured")
 
         for n in range(n_trials):
             t0 = time.perf_counter()
+            laser1.set_mode(mode)
+            laser1.set_freq(freq)
+            laser1.set_power(1)
             laser1.on()
             while (time.perf_counter() - t0 < width):
                 pass
@@ -80,6 +77,9 @@ class LaserTests(unittest.TestCase):
                 pass
         
             t0 = time.perf_counter()
+            laser2.set_mode(mode)
+            laser2.set_freq(freq)
+            laser2.set_power(1)
             laser2.on()
             while (time.perf_counter() - t0 < width):
                 pass


### PR DESCRIPTION
- move stimulation_site metadata from othertasks.py to laser_features.py
- set the power for each laser only once at the beginning of the experiment
- add stimulation_site metadata from multi-laser experiments
- add parameters for 
     - minimum isi, the minimum space between laser pulses
     - maximum stim time, the time after which stimulation stops
     - random pulse start time, so pulses don't start immediately after the state starts
     - random laser order, so the order of laser stimulation is swapped at random