### PR TITLE
Tracking task

### DIFF
--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -115,8 +115,11 @@ class TargetTracking(Sequence):
             print('WARNING: generator sample rate should equal FSM fps!')
 
         if self.repeat_freq_set:
-            self.next_trial = next(self.gen)
-            self._parse_next_trial()
+            try:
+                self.next_trial = next(self.gen)
+                self._parse_next_trial()
+            except StopIteration:
+                self.end_task()
 
         print(self.gen_index)
 

--- a/riglib/experiment/experiment.py
+++ b/riglib/experiment/experiment.py
@@ -802,11 +802,11 @@ class Sequence(LogExperiment):
 
         try:
             self.next_trial = next(self.gen)
-            self._parse_next_trial() # KP changed 10/26/22
+            # self._parse_next_trial() # KP changed 10/26/22
         except StopIteration:
             self.end_task()
 
-        # self._parse_next_trial()
+        self._parse_next_trial()
 
     def _parse_next_trial(self):
         '''


### PR DESCRIPTION
Undoes the change I made to the parent _start_wait function in experiment.py to fix bug that happens on last trial of laser experiments. I tested that tracking task is not affected by undoing the change. Also adds a condition to handle running out of trials in the generator when skipping ahead by 2 trials (to maintain alternating ref/dis freqs) after a tracking out penalty.