### PR TITLE
include parens in idx

### DIFF
--- a/db/html/static/resources/js/list.js
+++ b/db/html/static/resources/js/list.js
@@ -783,7 +783,7 @@ TaskEntry.prototype.new_row = function(info) {
     if (typeof(info.idx) == "number") {
         this.idx = info.idx;
     } else {
-        this.idx = parseInt(info.idx.match(/(\d+)/)[1]);
+        this.idx = parseInt(info.idx.match(/\((\d+\))/)[1]);
     }
     this.tr.removeClass("running active error testing")
 


### PR DESCRIPTION
i fixed a bug that prevents clicking on a new task entry until you reload the page. it affected experiments with numbers in the name, like "laser stimulation ch2 (10043)" because the 2 was interpreted as the id of the task instead of 10043.