### PR TITLE
Tracking task

### DIFF
--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -510,7 +510,7 @@ class ScreenTargetTracking(TargetTracking, Window):
         '''
         cursor_pos = self.plant.get_endpoint_pos()
         d = np.linalg.norm(cursor_pos - self.target.get_position())
-        return d <= (self.target_radius - self.cursor_radius) or super()._test_enter_target(time_in_state)
+        return d <= (self.target_radius - self.cursor_radius) or super()._test_enter_target(time_in_state) or (self.hold_time==0 and self.state=='trajectory')
 
     def _test_leave_target(self, time_in_state):
         '''

--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -121,6 +121,7 @@ class TargetTracking(Sequence):
             except StopIteration:
                 self.end_task()
 
+        # put everything below into a common start_wait function
         print(self.gen_index)
 
         self.trial_record['trial'] = self.calc_trial_num()

--- a/features/generator_features.py
+++ b/features/generator_features.py
@@ -171,6 +171,7 @@ class IncrementalRotation(traits.HasTraits):
     delta_rotation_x = traits.Float(0.0, desc="rotation step size about bmi3d x-axis in degrees")
 
     trials_per_increment = traits.Int(1, desc="number of successful trials per rotation step")
+    final_tracking_out_time = traits.Float(1.6, desc="Time allowed to be tracking outside the target for final rotation") # AKA tolerance time
 
     def init(self):    
         super().init()
@@ -189,7 +190,7 @@ class IncrementalRotation(traits.HasTraits):
         self.perturbation_rotation_z = self.init_rotation_z
         self.perturbation_rotation_x = self.init_rotation_x
 
-        print(self.pertubation_rotation, self.perturbation_rotation_z, self.perturbation_rotation_x)
+        print("Y", self.pertubation_rotation, "Z", self.perturbation_rotation_z, "X", self.perturbation_rotation_x)
 
     def _start_wait(self):
         super()._start_wait()
@@ -201,13 +202,18 @@ class IncrementalRotation(traits.HasTraits):
         self.perturbation_rotation_z = self.init_rotation_z + self.delta_rotation_z*num_deltas
         self.perturbation_rotation_x = self.init_rotation_x + self.delta_rotation_x*num_deltas
 
+        # change tracking out time of final rotation
+        if num_deltas+1 == self.num_increments:
+            self.tracking_out_time = self.final_tracking_out_time
+
         # stop incrementing once final perturbation rotation reached
         if self.num_trials_success >= self.num_increments * self.trials_per_increment:
             self.pertubation_rotation = self.final_rotation_y
             self.perturbation_rotation_z = self.final_rotation_z
             self.perturbation_rotation_x = self.final_rotation_x
         
-        print(self.pertubation_rotation, self.perturbation_rotation_z, self.perturbation_rotation_x)
+        print("Y", self.pertubation_rotation, "Z", self.perturbation_rotation_z, "X", self.perturbation_rotation_x)
+        print(self.tracking_out_time, "tracking out")
 
     def _start_wait_retry(self):
         super()._start_wait_retry()
@@ -219,13 +225,18 @@ class IncrementalRotation(traits.HasTraits):
         self.perturbation_rotation_z = self.init_rotation_z + self.delta_rotation_z*num_deltas
         self.perturbation_rotation_x = self.init_rotation_x + self.delta_rotation_x*num_deltas
 
+        # change tracking out time of final rotation
+        if num_deltas+1 == self.num_increments:
+            self.tracking_out_time = self.final_tracking_out_time
+
         # stop incrementing once final perturbation rotation reached
         if self.num_trials_success >= self.num_increments * self.trials_per_increment:
             self.pertubation_rotation = self.final_rotation_y
             self.perturbation_rotation_z = self.final_rotation_z
             self.perturbation_rotation_x = self.final_rotation_x
         
-        print(self.pertubation_rotation, self.perturbation_rotation_z, self.perturbation_rotation_x)
+        print("Y", self.pertubation_rotation, "Z", self.perturbation_rotation_z, "X", self.perturbation_rotation_x)
+        print(self.tracking_out_time, "tracking out")
 
     def _start_reward(self):
         super()._start_reward()

--- a/features/generator_features.py
+++ b/features/generator_features.py
@@ -176,17 +176,18 @@ class IncrementalRotation(traits.HasTraits):
     def init(self):    
         super().init()
         self.num_trials_success = 0
-        # NOTE: currently can only handle incremental rotations around one axis at a time
-        if self.final_rotation_y != self.init_rotation_y:
-            num_increments_y = int( (self.final_rotation_y-self.init_rotation_y) / self.delta_rotation_y+1 )
-        elif self.final_rotation_z != self.init_rotation_z:
-            num_increments_z = int( (self.final_rotation_z-self.init_rotation_z) / self.delta_rotation_z+1 )
-        elif self.final_rotation_x != self.init_rotation_x:
-            num_increments_x = int( (self.final_rotation_x-self.init_rotation_x) / self.delta_rotation_x+1 )
-        else:
-            print('Warning! Please specify an initial and final rotation.')
+        self.num_increments_y = 0
+        self.num_increments_z = 0
+        self.num_increments_x = 0
 
-        self.num_increments = np.max([num_increments_y, num_increments_z, num_increments_x])
+        if self.final_rotation_y != self.init_rotation_y:
+            self.num_increments_y = int( (self.final_rotation_y-self.init_rotation_y) / self.delta_rotation_y+1 )
+        if self.final_rotation_z != self.init_rotation_z:
+            self.num_increments_z = int( (self.final_rotation_z-self.init_rotation_z) / self.delta_rotation_z+1 )
+        if self.final_rotation_x != self.init_rotation_x:
+            self.num_increments_x = int( (self.final_rotation_x-self.init_rotation_x) / self.delta_rotation_x+1 )
+
+        self.max_num_increments = np.max([self.num_increments_y, self.num_increments_z, self.num_increments_x])
         self.pertubation_rotation = self.init_rotation_y
         self.perturbation_rotation_z = self.init_rotation_z
         self.perturbation_rotation_x = self.init_rotation_x
@@ -203,17 +204,19 @@ class IncrementalRotation(traits.HasTraits):
         self.perturbation_rotation_x = self.init_rotation_x + self.delta_rotation_x*num_deltas
 
         # change tracking out time of final rotation
-        if num_deltas+1 == self.num_increments:
+        if num_deltas+1 == self.max_num_increments:
             self.tracking_out_time = self.final_tracking_out_time
 
         # stop incrementing once final perturbation rotation reached
-        if self.num_trials_success >= self.num_increments * self.trials_per_increment:
+        if self.num_trials_success >= self.num_increments_y * self.trials_per_increment:
             self.pertubation_rotation = self.final_rotation_y
+        if self.num_trials_success >= self.num_increments_z * self.trials_per_increment:
             self.perturbation_rotation_z = self.final_rotation_z
+        if self.num_trials_success >= self.num_increments_x * self.trials_per_increment:
             self.perturbation_rotation_x = self.final_rotation_x
         
         print("Y", self.pertubation_rotation, "Z", self.perturbation_rotation_z, "X", self.perturbation_rotation_x)
-        print(self.tracking_out_time, "tracking out")        
+        print(self.tracking_out_time, "tracking out")
     
     def _start_wait(self):
         super()._start_wait()

--- a/features/generator_features.py
+++ b/features/generator_features.py
@@ -175,10 +175,21 @@ class IncrementalRotation(traits.HasTraits):
     def init(self):    
         super().init()
         self.num_trials_success = 0
-        self.num_increments = int( (self.final_rotation_y-self.init_rotation_y) / self.delta_rotation_y+1 )
+        if self.final_rotation_y != self.init_rotation_y:
+            rotation_info = [self.init_rotation_y, self.final_rotation_y, self.delta_rotation_y]
+        elif self.final_rotation_z != self.init_rotation_z:
+            rotation_info = [self.init_rotation_z, self.final_rotation_z, self.delta_rotation_z]
+        elif self.final_rotation_x != self.init_rotation_x:
+            rotation_info = [self.init_rotation_x, self.final_rotation_x, self.delta_rotation_x]
+        else:
+            print('Warning! Please specify an initial and final rotation.')
+
+        self.num_increments = int( (rotation_info[1]-rotation_info[0]) / rotation_info[2]+1 )
         self.pertubation_rotation = self.init_rotation_y
         self.perturbation_rotation_z = self.init_rotation_z
         self.perturbation_rotation_x = self.init_rotation_x
+
+        print(self.pertubation_rotation, self.perturbation_rotation_z, self.perturbation_rotation_x)
 
     def _start_wait(self):
         super()._start_wait()
@@ -196,7 +207,7 @@ class IncrementalRotation(traits.HasTraits):
             self.perturbation_rotation_z = self.final_rotation_z
             self.perturbation_rotation_x = self.final_rotation_x
         
-        print(self.pertubation_rotation)
+        print(self.pertubation_rotation, self.perturbation_rotation_z, self.perturbation_rotation_x)
 
     def _start_wait_retry(self):
         super()._start_wait_retry()
@@ -214,7 +225,7 @@ class IncrementalRotation(traits.HasTraits):
             self.perturbation_rotation_z = self.final_rotation_z
             self.perturbation_rotation_x = self.final_rotation_x
         
-        print(self.pertubation_rotation)
+        print(self.pertubation_rotation, self.perturbation_rotation_z, self.perturbation_rotation_x)
 
     def _start_reward(self):
         super()._start_reward()

--- a/features/generator_features.py
+++ b/features/generator_features.py
@@ -176,6 +176,7 @@ class IncrementalRotation(traits.HasTraits):
     def init(self):    
         super().init()
         self.num_trials_success = 0
+        # NOTE: currently can only handle incremental rotations around one axis at a time
         if self.final_rotation_y != self.init_rotation_y:
             rotation_info = [self.init_rotation_y, self.final_rotation_y, self.delta_rotation_y]
         elif self.final_rotation_z != self.init_rotation_z:

--- a/features/generator_features.py
+++ b/features/generator_features.py
@@ -192,8 +192,9 @@ class IncrementalRotation(traits.HasTraits):
         self.perturbation_rotation_x = self.init_rotation_x
 
         print("Y", self.pertubation_rotation, "Z", self.perturbation_rotation_z, "X", self.perturbation_rotation_x)
-
+    
     def _start_wait(self):
+        # incremental_start_wait called by both start waits here
         super()._start_wait()
         # determine the current rotation step
         num_deltas = int(self.num_trials_success / self.trials_per_increment)

--- a/features/generator_features.py
+++ b/features/generator_features.py
@@ -178,15 +178,15 @@ class IncrementalRotation(traits.HasTraits):
         self.num_trials_success = 0
         # NOTE: currently can only handle incremental rotations around one axis at a time
         if self.final_rotation_y != self.init_rotation_y:
-            rotation_info = [self.init_rotation_y, self.final_rotation_y, self.delta_rotation_y]
+            num_increments_y = int( (self.final_rotation_y-self.init_rotation_y) / self.delta_rotation_y+1 )
         elif self.final_rotation_z != self.init_rotation_z:
-            rotation_info = [self.init_rotation_z, self.final_rotation_z, self.delta_rotation_z]
+            num_increments_z = int( (self.final_rotation_z-self.init_rotation_z) / self.delta_rotation_z+1 )
         elif self.final_rotation_x != self.init_rotation_x:
-            rotation_info = [self.init_rotation_x, self.final_rotation_x, self.delta_rotation_x]
+            num_increments_x = int( (self.final_rotation_x-self.init_rotation_x) / self.delta_rotation_x+1 )
         else:
             print('Warning! Please specify an initial and final rotation.')
 
-        self.num_increments = int( (rotation_info[1]-rotation_info[0]) / rotation_info[2]+1 )
+        self.num_increments = np.max([num_increments_y, num_increments_z, num_increments_x])
         self.pertubation_rotation = self.init_rotation_y
         self.perturbation_rotation_z = self.init_rotation_z
         self.perturbation_rotation_x = self.init_rotation_x

--- a/features/generator_features.py
+++ b/features/generator_features.py
@@ -193,9 +193,7 @@ class IncrementalRotation(traits.HasTraits):
 
         print("Y", self.pertubation_rotation, "Z", self.perturbation_rotation_z, "X", self.perturbation_rotation_x)
     
-    def _start_wait(self):
-        # incremental_start_wait called by both start waits here
-        super()._start_wait()
+    def incremental_start_wait(self):
         # determine the current rotation step
         num_deltas = int(self.num_trials_success / self.trials_per_increment)
 
@@ -215,30 +213,15 @@ class IncrementalRotation(traits.HasTraits):
             self.perturbation_rotation_x = self.final_rotation_x
         
         print("Y", self.pertubation_rotation, "Z", self.perturbation_rotation_z, "X", self.perturbation_rotation_x)
-        print(self.tracking_out_time, "tracking out")
+        print(self.tracking_out_time, "tracking out")        
+    
+    def _start_wait(self):
+        super()._start_wait()
+        self.incremental_start_wait()
 
     def _start_wait_retry(self):
         super()._start_wait_retry()
-        # determine the current rotation step
-        num_deltas = int(self.num_trials_success / self.trials_per_increment)
-
-        # increment the current perturbation rotation by delta
-        self.pertubation_rotation = self.init_rotation_y + self.delta_rotation_y*num_deltas
-        self.perturbation_rotation_z = self.init_rotation_z + self.delta_rotation_z*num_deltas
-        self.perturbation_rotation_x = self.init_rotation_x + self.delta_rotation_x*num_deltas
-
-        # change tracking out time of final rotation
-        if num_deltas+1 == self.num_increments:
-            self.tracking_out_time = self.final_tracking_out_time
-
-        # stop incrementing once final perturbation rotation reached
-        if self.num_trials_success >= self.num_increments * self.trials_per_increment:
-            self.pertubation_rotation = self.final_rotation_y
-            self.perturbation_rotation_z = self.final_rotation_z
-            self.perturbation_rotation_x = self.final_rotation_x
-        
-        print("Y", self.pertubation_rotation, "Z", self.perturbation_rotation_z, "X", self.perturbation_rotation_x)
-        print(self.tracking_out_time, "tracking out")
+        self.incremental_start_wait()
 
     def _start_reward(self):
         super()._start_reward()


### PR DESCRIPTION
I previously added a feature that can be used with tracking task to specify incremental rotations of the hand-to-cursor mapping. Here I updated that feature so that you can specify a different tracking out time for the final rotation block.
I also updated tracking task code so that setting the hold time to 0 will cause trials to automatically start (no opt-in hold required). 

NOTE: The incremental rotations can occur around any one of the major bmi3d axes, but the current implementation only handles rotations around one axis at a time (meaning you can not simultaneously create incremental rotations that involve 2 axes). 