### PR TITLE
Update pygame

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="aolab-bmi3d",
-    version="1.0.5",
+    version="1.0.6",
     author="Lots of people",
     description="electrophysiology experimental rig library",
     packages=setuptools.find_packages(),
@@ -21,7 +21,7 @@ setuptools.setup(
         "pandas",
         "patsy",
         "statsmodels",
-        "pygame",
+        "pygame==2.5.0",
         "PyOpenGL",
         "pylibftdi",
         "sphinx",


### PR DESCRIPTION
the newest pygame version doesn't want to install. But old version we were using (1.9.6) doesn't support joystick.