### PR TITLE
Multi tablet

### DIFF
--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -407,8 +407,12 @@ class ScreenTargetTracking(TargetTracking, Window):
             self.trajectory = VirtualCableTarget(target_radius=self.trajectory_radius, target_color=target_colors[self.trajectory_color])
 
             # This is the progress bar
-            self.bar = VirtualRectangularTarget(target_width=1, target_height=0, target_color=(0., 1., 0., 0.75), starting_pos=[0,0,9])
+            self.bar = VirtualRectangularTarget(target_width=1, target_height=0, target_color=(0., 1., 0., 0.75), starting_pos=[0,-15,9])
             # print('INIT TRAJ')
+
+            # This is a black cube that hides the "lookbehind" of trajectory
+            self.box = VirtualRectangularTarget(target_width=20, target_height=10, target_color=(0, 0, 0, 1), starting_pos=[-10,-1,0])
+            # target_width of RectangularTarget is total height, target_height is 1/2 of total width (from center to edge)
 
         # Declare any plant attributes which must be saved to the HDF file at the _cycle rate
         for attr in self.plant.hdf_attrs:
@@ -482,7 +486,7 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     def update_frame(self):
         self.target.move_to_position(np.array([0,0,self.targs[self.frame_index+self.lookahead][2]])) # xzy
-        self.trajectory.move_to_position(np.array([-self.frame_index/3,0,0])) # same update constant works for 60 and 120 hz
+        self.trajectory.move_to_position(np.array([-self.frame_index/3,10,0])) # same update constant works for 60 and 120 hz
         self.target.show()
         self.trajectory.show()
         self.frame_index +=1
@@ -520,6 +524,10 @@ class ScreenTargetTracking(TargetTracking, Window):
                 self.add_model(model)
                 self.bar.hide()
 
+            for model in self.box.graphics_models:
+                self.add_model(model)
+                self.box.hide()
+
         # Allow 2d movement
         if not self.always_1d:
             self.limit1d = False
@@ -554,6 +562,8 @@ class ScreenTargetTracking(TargetTracking, Window):
         self.trajectory.reset()
         self.bar.hide()
         self.bar.reset()
+        self.box.hide()
+        self.box.reset()
 
     def _start_wait(self):
         super()._start_wait()
@@ -570,24 +580,23 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     def _while_wait_retry(self):
         super()._while_wait_retry()
-        # # Add disturbance
 
     def _start_trajectory(self):
         super()._start_trajectory()
         if self.frame_index == 0:
             self.target.move_to_position(np.array([0,0,self.targs[self.frame_index+self.lookahead][2]])) # tablet screen x-axis ranges -19,19, center 0
-            self.trajectory.move_to_position(np.array([0,0,0])) # tablet screen x-axis ranges 0,41.33333, center 22ish
+            self.trajectory.move_to_position(np.array([0,10,0])) # tablet screen x-axis ranges 0,41.33333, center 22ish
             # print(self.target.get_position())
             # print(self.trajectory.get_position())
 
             self.target.show()
             self.trajectory.show()
+            self.box.show()
             # print('SHOW TRAJ')
             self.sync_event('TARGET_ON')
 
     def _while_trajectory(self):
         super()._while_trajectory()
-        # # Add disturbance
 
     def _start_hold(self):
         super()._start_hold()
@@ -598,7 +607,6 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     def _while_hold(self):
         super()._while_hold()
-        # # Add disturbance
 
     def _start_tracking_in(self):
         super()._start_tracking_in()
@@ -689,7 +697,6 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     def _while_hold_penalty(self):
         super()._while_hold_penalty()
-        # # Add disturbance
 
     def _end_hold_penalty(self):
         super()._end_hold_penalty()
@@ -709,7 +716,6 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     def _while_tracking_out_penalty(self):
         super()._while_tracking_out_penalty()
-        # # Add disturbance
 
     def _end_tracking_out_penalty(self):
         super()._end_tracking_out_penalty()
@@ -731,7 +737,6 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     def _while_reward(self):
         super()._while_reward()
-        # # Add disturbance
 
     def _end_reward(self):
         super()._end_reward()

--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -591,7 +591,6 @@ class ScreenTargetTracking(TargetTracking, Window):
 
             self.target.show()
             self.trajectory.show()
-            self.box.show()
             # print('SHOW TRAJ')
             self.sync_event('TARGET_ON')
 

--- a/db/html/static/resources/js/report.js
+++ b/db/html/static/resources/js/report.js
@@ -43,7 +43,9 @@ Report.prototype.activate = function() {
     //var on_windows = window.navigator.userAgent.indexOf("Windows") > 0;
     if (!this.ws) {  // && !on_windows) { some websocket issues on windows..
         // Create a new JS WebSocket object
-        this.ws = new WebSocket("ws://"+hostname.split(":")[0]+":8001/connect");
+        var host = hostname.split(":")[0]
+        var port = Number(hostname.split(":")[1]) + 1
+        this.ws = new WebSocket("ws://"+host+":"+port+"/connect");
 
         this.ws.onmessage = function(evt) {
             debug(evt.data);

--- a/db/runserver.sh
+++ b/db/runserver.sh
@@ -49,6 +49,7 @@ elif [ "$HOST" = "booted-server" ]; then
     conda activate bmi3d
 fi
 export DISPLAY=$DISPLAY
+export BMI3D_PORT=$PORT
 
 # #Check /storage (exist )
 # storage=$(python $BMI3D/config_files/check_storage.py 2>&1)

--- a/db/tracker/websocket.py
+++ b/db/tracker/websocket.py
@@ -71,7 +71,8 @@ class Server(mp.Process):
         import asyncio
         asyncio.set_event_loop(asyncio.new_event_loop())
 
-        application.listen(8001)
+        port = int(os.environ['BMI3D_PORT'])
+        application.listen(port+1)
         self.ioloop = tornado.ioloop.IOLoop.current()
         self.ioloop.add_handler(self._pipe, self._send, self.ioloop.READ)
         self.ioloop.add_handler(self._outp, self._stdout, self.ioloop.READ)

--- a/features/__init__.py
+++ b/features/__init__.py
@@ -6,7 +6,7 @@ task/experiment by multiple inheritance.
 from features.debug_features import Profiler, OnlineAnalysis
 from features.laser_features import QwalorLaser, MultiQwalorLaser, SwitchedQwalorLaser, LaserState
 from riglib.stereo_opengl.window import WindowWithExperimenterDisplay, Window2D
-from .generator_features import Autostart, AdaptiveGenerator, IgnoreCorrectness, PoissonWait, Progressbar_fixation
+from .generator_features import Autostart, AdaptiveGenerator, IgnoreCorrectness, PoissonWait, Progressbar_fixation, HideLeftTrajectory
 from .peripheral_device_features import Button, Joystick, DualJoystick, Joystick_plus_TouchSensor, KeyboardControl, MouseControl, ForceControl
 from .reward_features import RewardSystem, TTLReward, JuiceLogging, PelletReward, JackpotRewards, ProgressBar, TrackingRewards
 from .eyetracker_features import EyeData, CalibratedEyeData, SimulatedEyeData, FixationStart, EyeConstrained, EyeCalibration, EyeStreaming
@@ -80,7 +80,8 @@ built_in_features = dict(
     eye_calibration=EyeCalibration, 
     force_sensor=ForceControl,
     show_fixation_progress=Progressbar_fixation,
-    clda_kfrml=CLDA_KFRML_IntendedVelocity
+    clda_kfrml=CLDA_KFRML_IntendedVelocity,
+    hide_left_trajectory=HideLeftTrajectory,
 )
 
 # >>> features.built_in_features['autostart'].__module__

--- a/features/generator_features.py
+++ b/features/generator_features.py
@@ -292,3 +292,16 @@ class IncrementalRotation(traits.HasTraits):
     def _start_reward(self):
         super()._start_reward()
         self.num_trials_success += 1
+
+
+class HideLeftTrajectory(traits.HasTraits):
+    '''
+    Cover left side of tracking task screen with a black box. 
+    This will cover the 'lookbehind' of the target trajectory. 
+    Useful for task with bumpers.
+    '''
+
+    def _start_trajectory(self):
+        super()._start_trajectory()
+        if self.frame_index == 0:
+            self.box.show()

--- a/features/reward_features.py
+++ b/features/reward_features.py
@@ -235,7 +235,7 @@ class ProgressBar(traits.HasTraits):
                 self.remove_model(model)
             del self.bar
 
-        self.bar = VirtualRectangularTarget(target_width=1.3, target_height=self.tracking_rate, target_color=(0., 1., 0., 0.75), starting_pos=[self.tracking_rate-self.bar_width,0,9])
+        self.bar = VirtualRectangularTarget(target_width=1.3, target_height=self.tracking_rate, target_color=(0., 1., 0., 0.75), starting_pos=[self.tracking_rate-self.bar_width,-15,9])
         for model in self.bar.graphics_models:
             self.add_model(model)
         self.bar.show()
@@ -251,7 +251,7 @@ class ProgressBar(traits.HasTraits):
         self.reward_frame_index += 1
         reward_numframe = self.reward_time*self.fps
         reward_amount = self.tracking_rate - self.reward_frame_index*self.tracking_rate/reward_numframe
-        self.bar = VirtualRectangularTarget(target_width=1.3, target_height=reward_amount, target_color=(0., 1., 0., 0.75), starting_pos=[reward_amount-self.bar_width,0,9])
+        self.bar = VirtualRectangularTarget(target_width=1.3, target_height=reward_amount, target_color=(0., 1., 0., 0.75), starting_pos=[reward_amount-self.bar_width,-15,9])
         for model in self.bar.graphics_models:
             self.add_model(model)
         self.bar.show()        

--- a/riglib/experiment/task_wrapper.py
+++ b/riglib/experiment/task_wrapper.py
@@ -151,7 +151,8 @@ class TaskWrapper(RPCProcess):
             try:
                 # get object representing function calls to the remote database
                 # returns the result of db.tracker.dbq.rpc_handler
-                database = xmlrpc.client.ServerProxy("http://localhost:8000/RPC2/", allow_none=True)
+                port = int(os.environ['BMI3D_PORT'])
+                database = xmlrpc.client.ServerProxy(f"http://localhost:{port}/RPC2/", allow_none=True)
                 # from tracker import dbq as database
                 cleanup_successful = self.target.cleanup(database, self.saveid, subject=self.subj)
                 database.cleanup(self.saveid)


### PR DESCRIPTION
ability to set the port and display parameters on startup. 
as yet undocumented startup command is:
`runserver.sh [-log] [-test] <display> <port>`
for example,
`runserver.sh :0 8000` (equivalent to `runserver.sh`, the default) starts bmi3d on port 8000 and display :0
or
`runserver.sh -test :1 9000` starts bmi3d in test mode on port 9000 and display :1

for two tablets, you would need to start two instances with different displays and ports. i tested using:
`runserver.sh :1 8000`
`runserver.sh :2 9000`
and it seemed to work, but i didn't test thoroughly 