### PR TITLE
Reward system for multiple tablets running concurrently

### DIFF
--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -407,8 +407,12 @@ class ScreenTargetTracking(TargetTracking, Window):
             self.trajectory = VirtualCableTarget(target_radius=self.trajectory_radius, target_color=target_colors[self.trajectory_color])
 
             # This is the progress bar
-            self.bar = VirtualRectangularTarget(target_width=1, target_height=0, target_color=(0., 1., 0., 0.75), starting_pos=[0,0,9])
+            self.bar = VirtualRectangularTarget(target_width=1, target_height=0, target_color=(0., 1., 0., 0.75), starting_pos=[0,-15,9])
             # print('INIT TRAJ')
+
+            # This is a black cube that hides the "lookbehind" of trajectory
+            self.box = VirtualRectangularTarget(target_width=20, target_height=10, target_color=(0, 0, 0, 1), starting_pos=[-10,-1,0])
+            # target_width of RectangularTarget is total height, target_height is 1/2 of total width (from center to edge)
 
         # Declare any plant attributes which must be saved to the HDF file at the _cycle rate
         for attr in self.plant.hdf_attrs:
@@ -482,7 +486,7 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     def update_frame(self):
         self.target.move_to_position(np.array([0,0,self.targs[self.frame_index+self.lookahead][2]])) # xzy
-        self.trajectory.move_to_position(np.array([-self.frame_index/3,0,0])) # same update constant works for 60 and 120 hz
+        self.trajectory.move_to_position(np.array([-self.frame_index/3,10,0])) # same update constant works for 60 and 120 hz
         self.target.show()
         self.trajectory.show()
         self.frame_index +=1
@@ -520,6 +524,10 @@ class ScreenTargetTracking(TargetTracking, Window):
                 self.add_model(model)
                 self.bar.hide()
 
+            for model in self.box.graphics_models:
+                self.add_model(model)
+                self.box.hide()
+
         # Allow 2d movement
         if not self.always_1d:
             self.limit1d = False
@@ -554,6 +562,8 @@ class ScreenTargetTracking(TargetTracking, Window):
         self.trajectory.reset()
         self.bar.hide()
         self.bar.reset()
+        self.box.hide()
+        self.box.reset()
 
     def _start_wait(self):
         super()._start_wait()
@@ -570,13 +580,12 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     def _while_wait_retry(self):
         super()._while_wait_retry()
-        # # Add disturbance
 
     def _start_trajectory(self):
         super()._start_trajectory()
         if self.frame_index == 0:
             self.target.move_to_position(np.array([0,0,self.targs[self.frame_index+self.lookahead][2]])) # tablet screen x-axis ranges -19,19, center 0
-            self.trajectory.move_to_position(np.array([0,0,0])) # tablet screen x-axis ranges 0,41.33333, center 22ish
+            self.trajectory.move_to_position(np.array([0,10,0])) # tablet screen x-axis ranges 0,41.33333, center 22ish
             # print(self.target.get_position())
             # print(self.trajectory.get_position())
 
@@ -587,7 +596,6 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     def _while_trajectory(self):
         super()._while_trajectory()
-        # # Add disturbance
 
     def _start_hold(self):
         super()._start_hold()
@@ -598,7 +606,6 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     def _while_hold(self):
         super()._while_hold()
-        # # Add disturbance
 
     def _start_tracking_in(self):
         super()._start_tracking_in()
@@ -689,7 +696,6 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     def _while_hold_penalty(self):
         super()._while_hold_penalty()
-        # # Add disturbance
 
     def _end_hold_penalty(self):
         super()._end_hold_penalty()
@@ -709,7 +715,6 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     def _while_tracking_out_penalty(self):
         super()._while_tracking_out_penalty()
-        # # Add disturbance
 
     def _end_tracking_out_penalty(self):
         super()._end_tracking_out_penalty()
@@ -731,7 +736,6 @@ class ScreenTargetTracking(TargetTracking, Window):
 
     def _while_reward(self):
         super()._while_reward()
-        # # Add disturbance
 
     def _end_reward(self):
         super()._end_reward()

--- a/db/html/static/resources/js/report.js
+++ b/db/html/static/resources/js/report.js
@@ -43,7 +43,9 @@ Report.prototype.activate = function() {
     //var on_windows = window.navigator.userAgent.indexOf("Windows") > 0;
     if (!this.ws) {  // && !on_windows) { some websocket issues on windows..
         // Create a new JS WebSocket object
-        this.ws = new WebSocket("ws://"+hostname.split(":")[0]+":8001/connect");
+        var host = hostname.split(":")[0]
+        var port = Number(hostname.split(":")[1]) + 1
+        this.ws = new WebSocket("ws://"+host+":"+port+"/connect");
 
         this.ws.onmessage = function(evt) {
             debug(evt.data);

--- a/db/runserver.sh
+++ b/db/runserver.sh
@@ -1,21 +1,5 @@
 #!/bin/bash
 
-# Set display
-HOST=`hostname -s`
-if [ "$HOST" = "pagaiisland2" ] || [ "$HOST" = "siberut-bmi" ] || [ "$HOST" = "human-bmi" ]; then
-    export DISPLAY=':0.1'
-    echo "Moving display to :0.1"
-elif [ "$HOST" = "pagaiisland-surface" ]; then
-    export DISPLAY=localhost:0
-    export LIBGL_ALWAYS_INDIRECT=0
-    echo "success"
-elif [ "$HOST" = "booted-server" ]; then
-    export DISPLAY=':1'
-    Xvnc :1 -securityTypes None -geometry 1920x1080 -nocursor &
-    eval "$(conda shell.bash hook)"
-    conda activate bmi3d
-fi
-
 # Find the BMI3D directory
 FILE=$(realpath "$0")
 DB=$(dirname "$FILE")
@@ -25,8 +9,21 @@ cd $DB
 # Check inputs
 LOG=false
 TEST=false
+PORT=8000
+DISPLAY=':0'
 [[ "$@" =~ '-log' ]] && LOG=true
 [[ "$@" =~ '-test' ]] && TEST=true
+ARGCOUNT=$#
+[[ "$LOG" == "true" ]] && ARGCOUNT=$((ARGCOUNT-1))
+[[ "$TEST" == "true" ]] && ARGCOUNT=$((ARGCOUNT-1))
+if (($ARGCOUNT > 0)); then
+    DISPLAY=${@:1+$#-$ARGCOUNT:1}
+    echo $DISPLAY
+fi
+if (($ARGCOUNT > 1)); then
+    PORT=${@:$#:1}
+    echo $PORT
+fi
 
 # Start logging
 if [ "$LOG" == "false" ]
@@ -37,6 +34,22 @@ then
     /bin/bash ./runserver.sh -log "$@" | tee -a $BMI3D/log/runserver_log
     exit 0
 fi
+
+# Set display
+HOST=`hostname -s`
+if [ "$HOST" = "pagaiisland2" ] || [ "$HOST" = "siberut-bmi" ]; then
+    DISPLAY=':0.1'
+    echo "Moving display to :0.1"
+elif [ "$HOST" = "booted-server" ]; then
+    if [ "$DISPLAY" = ":0" ]; then
+        DISPLAY=':1'
+    fi
+    Xvnc $DISPLAY -securityTypes None -geometry 1920x1080 -nocursor &
+    eval "$(conda shell.bash hook)"
+    conda activate bmi3d
+fi
+export DISPLAY=$DISPLAY
+export BMI3D_PORT=$PORT
 
 # #Check /storage (exist )
 # storage=$(python $BMI3D/config_files/check_storage.py 2>&1)
@@ -116,7 +129,7 @@ trap "kill 0" EXIT
 
 # Start python processes
 cd $BMI3D
-python manage.py runserver 0.0.0.0:8000 --noreload &
+python manage.py runserver 0.0.0.0:$PORT --noreload &
 # if [ "$HOST" = "pagaiisland2" ] || [ "$HOST" = "siberut-bmi" ]; then
 #     celery -A db.tracker worker -l INFO &
 # fi

--- a/db/tracker/websocket.py
+++ b/db/tracker/websocket.py
@@ -71,7 +71,8 @@ class Server(mp.Process):
         import asyncio
         asyncio.set_event_loop(asyncio.new_event_loop())
 
-        application.listen(8001)
+        port = int(os.environ['BMI3D_PORT'])
+        application.listen(port+1)
         self.ioloop = tornado.ioloop.IOLoop.current()
         self.ioloop.add_handler(self._pipe, self._send, self.ioloop.READ)
         self.ioloop.add_handler(self._outp, self._stdout, self.ioloop.READ)

--- a/features/__init__.py
+++ b/features/__init__.py
@@ -7,7 +7,7 @@ from features.debug_features import Profiler, OnlineAnalysis
 from features.laser_features import QwalorLaser, MultiQwalorLaser, SwitchedQwalorLaser, LaserState
 from riglib.stereo_opengl.window import WindowWithExperimenterDisplay, Window2D
 from riglib.stereo_opengl.openxr import WindowVR
-from .generator_features import Autostart, AdaptiveGenerator, IgnoreCorrectness, PoissonWait, Progressbar_fixation, HideLeftTrajectory
+from .generator_features import Autostart, RandomDelay, AdaptiveGenerator, IgnoreCorrectness, PoissonWait, Progressbar_fixation, HideLeftTrajectory
 from .peripheral_device_features import Button, Joystick, DualJoystick, Joystick_plus_TouchSensor, KeyboardControl, MouseControl, ForceControl
 from .reward_features import RewardSystem, TTLReward, JuiceLogging, PelletReward, JackpotRewards, ProgressBar, TrackingRewards, RewardAudio, PenaltyAudio, ScoreRewards
 from .eyetracker_features import EyeData, CalibratedEyeData, SimulatedEyeData, FixationStart, EyeConstrained, EyeCalibration, EyeStreaming

--- a/features/__init__.py
+++ b/features/__init__.py
@@ -7,7 +7,7 @@ from features.debug_features import Profiler, OnlineAnalysis
 from features.laser_features import QwalorLaser, MultiQwalorLaser, SwitchedQwalorLaser, LaserState
 from riglib.stereo_opengl.window import WindowWithExperimenterDisplay, Window2D
 from riglib.stereo_opengl.openxr import WindowVR
-from .generator_features import Autostart, AdaptiveGenerator, IgnoreCorrectness, PoissonWait, RandomDelay, Progressbar_fixation
+from .generator_features import Autostart, AdaptiveGenerator, IgnoreCorrectness, PoissonWait, Progressbar_fixation, HideLeftTrajectory
 from .peripheral_device_features import Button, Joystick, DualJoystick, Joystick_plus_TouchSensor, KeyboardControl, MouseControl, ForceControl
 from .reward_features import RewardSystem, TTLReward, JuiceLogging, PelletReward, JackpotRewards, ProgressBar, TrackingRewards, RewardAudio, PenaltyAudio, ScoreRewards
 from .eyetracker_features import EyeData, CalibratedEyeData, SimulatedEyeData, FixationStart, EyeConstrained, EyeCalibration, EyeStreaming
@@ -88,7 +88,8 @@ built_in_features = dict(
     eye_calibration=EyeCalibration, 
     force_sensor=ForceControl,
     show_fixation_progress=Progressbar_fixation,
-    clda_kfrml=CLDA_KFRML_IntendedVelocity
+    clda_kfrml=CLDA_KFRML_IntendedVelocity,
+    hide_left_trajectory=HideLeftTrajectory,
 )
 
 # >>> features.built_in_features['autostart'].__module__

--- a/features/generator_features.py
+++ b/features/generator_features.py
@@ -292,3 +292,16 @@ class IncrementalRotation(traits.HasTraits):
     def _start_reward(self):
         super()._start_reward()
         self.num_trials_success += 1
+
+
+class HideLeftTrajectory(traits.HasTraits):
+    '''
+    Cover left side of tracking task screen with a black box. 
+    This will cover the 'lookbehind' of the target trajectory. 
+    Useful for task with bumpers.
+    '''
+
+    def _start_trajectory(self):
+        super()._start_trajectory()
+        if self.frame_index == 0:
+            self.box.show()

--- a/features/reward_features.py
+++ b/features/reward_features.py
@@ -242,7 +242,7 @@ class ProgressBar(traits.HasTraits):
                 self.remove_model(model)
             del self.bar
 
-        self.bar = VirtualRectangularTarget(target_width=1.3, target_height=self.tracking_rate, target_color=(0., 1., 0., 0.75), starting_pos=[self.tracking_rate-self.bar_width,0,9])
+        self.bar = VirtualRectangularTarget(target_width=1.3, target_height=self.tracking_rate, target_color=(0., 1., 0., 0.75), starting_pos=[self.tracking_rate-self.bar_width,-15,9])
         for model in self.bar.graphics_models:
             self.add_model(model)
         self.bar.show()
@@ -258,7 +258,7 @@ class ProgressBar(traits.HasTraits):
         self.reward_frame_index += 1
         reward_numframe = self.reward_time*self.fps
         reward_amount = self.tracking_rate - self.reward_frame_index*self.tracking_rate/reward_numframe
-        self.bar = VirtualRectangularTarget(target_width=1.3, target_height=reward_amount, target_color=(0., 1., 0., 0.75), starting_pos=[reward_amount-self.bar_width,0,9])
+        self.bar = VirtualRectangularTarget(target_width=1.3, target_height=reward_amount, target_color=(0., 1., 0., 0.75), starting_pos=[reward_amount-self.bar_width,-15,9])
         for model in self.bar.graphics_models:
             self.add_model(model)
         self.bar.show()        

--- a/features/reward_features.py
+++ b/features/reward_features.py
@@ -73,6 +73,8 @@ class PelletReward(RewardSystem):
         
         if self.port_value == 8000:
             self.ip_address = "192.168.0.62"
+        elif self.port_value == 9000:
+            self.ip_address = "192.168.0.200"
         else:
             print('uh oh')
             self.ip_address = "192.168.0.150"

--- a/features/reward_features.py
+++ b/features/reward_features.py
@@ -62,13 +62,20 @@ class PelletReward(RewardSystem):
     '''
     Trigger pellet rewards.    
     '''
-    pellets_per_reward = traits.Int(1, desc='The number of pellets to dispense per reward.')      
+    pellets_per_reward = traits.Int(1, desc='The number of pellets to dispense per reward.') 
+    port_value = traits.Int(8000, desc='The port value to identify which tablet is running.')     
 
     def __init__(self, *args, **kwargs):
         from riglib.tablet_reward import RemoteReward
         super(RewardSystem, self).__init__(*args, **kwargs)
         self.reward = RemoteReward()
         self.reportstats['Reward #'] = 0
+        
+        if port_value == 8000:
+            self.ip_address = "192.168.0.62"
+        else:
+            print('uh oh')
+            self.ip_address = "192.168.0.150"
 
     def _start_reward(self):
         if hasattr(super(RewardSystem, self), '_start_reward'):
@@ -77,7 +84,7 @@ class PelletReward(RewardSystem):
         
         if self.reportstats['Reward #'] % self.trials_per_reward == 0:
             for _ in range(self.pellets_per_reward): # call trigger num of pellets_per_reward time
-                self.reward.trigger()
+                self.reward.trigger(self.ip_address)
                 time.sleep(0.5) # wait for 0.5 seconds
 
     def _end_reward(self):

--- a/features/reward_features.py
+++ b/features/reward_features.py
@@ -71,7 +71,7 @@ class PelletReward(RewardSystem):
         self.reward = RemoteReward()
         self.reportstats['Reward #'] = 0
         
-        if port_value == 8000:
+        if self.port_value == 8000:
             self.ip_address = "192.168.0.62"
         else:
             print('uh oh')

--- a/riglib/experiment/task_wrapper.py
+++ b/riglib/experiment/task_wrapper.py
@@ -151,7 +151,8 @@ class TaskWrapper(RPCProcess):
             try:
                 # get object representing function calls to the remote database
                 # returns the result of db.tracker.dbq.rpc_handler
-                database = xmlrpc.client.ServerProxy("http://localhost:8000/RPC2/", allow_none=True)
+                port = int(os.environ['BMI3D_PORT'])
+                database = xmlrpc.client.ServerProxy(f"http://localhost:{port}/RPC2/", allow_none=True)
                 # from tracker import dbq as database
                 cleanup_successful = self.target.cleanup(database, self.saveid, subject=self.subj)
                 database.cleanup(self.saveid)

--- a/riglib/tablet_reward.py
+++ b/riglib/tablet_reward.py
@@ -44,8 +44,9 @@ class RemoteReward():
         self.hostName = "192.168.0.200"
         self.serverPort = 8080
 
-    def trigger(self):
-        url = f"http://{self.hostName}:{self.serverPort}"
+    def trigger(self, ip_address):
+        url = f"http://{self.ip_address}:{self.serverPort}"
+        print(url)
         try:
             requests.post(url, timeout=3)
         except:

--- a/riglib/tablet_reward.py
+++ b/riglib/tablet_reward.py
@@ -45,7 +45,7 @@ class RemoteReward():
         self.serverPort = 8080
 
     def trigger(self, ip_address):
-        url = f"http://{self.ip_address}:{self.serverPort}"
+        url = f"http://{ip_address}:{self.serverPort}"
         print(url)
         try:
             requests.post(url, timeout=3)


### PR DESCRIPTION
Added "port number" parameter (should be 8000 or 9000 for Tablet A and Tablet B), to run two tablets and reward systems synchronously. The IP address for port 8000 (Tablet A) may change in the future (which will require changing the ip_address information in the reward_features.py file. To fix the IP address, this should be updated via tp-link. (The password for this is currently unknown!)