### PR TITLE
Tracking add ramp state

### DIFF
--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -682,9 +682,8 @@ class ScreenTargetTracking(TargetTracking, Window):
     def _start_tracking_in_ramp(self):
         super()._start_tracking_in_ramp()
         self.setup_start_tracking_in()
-
-        print('START TRACKING RAMP', self.ramp_counter[self.frame_index])
-        self.sync_event('CURSOR_ENTER_TARGET', self.ramp_counter[self.frame_index]) # TODO test when there is only a ramp down
+        # print('START TRACKING RAMP', self.ramp_counter[self.frame_index])
+        self.sync_event('CURSOR_ENTER_TARGET', self.ramp_counter[self.frame_index])
 
     def _while_tracking_in_ramp(self):
         super()._while_tracking_in_ramp()
@@ -693,7 +692,7 @@ class ScreenTargetTracking(TargetTracking, Window):
     def _start_tracking_in(self):
         super()._start_tracking_in()
         self.setup_start_tracking_in()
-        print('START TRACKING')
+        # print('START TRACKING')
         self.sync_event('CURSOR_ENTER_TARGET')
 
     def _while_tracking_in(self):
@@ -703,7 +702,7 @@ class ScreenTargetTracking(TargetTracking, Window):
     def _start_tracking_out_ramp(self):
         super()._start_tracking_out_ramp()
         self.setup_start_tracking_out()
-        print('STOP TRACKING RAMP', self.ramp_counter[self.frame_index])
+        # print('STOP TRACKING RAMP', self.ramp_counter[self.frame_index])
         self.sync_event('CURSOR_LEAVE_TARGET', self.ramp_counter[self.frame_index])
 
     def _while_tracking_out_ramp(self):
@@ -713,7 +712,7 @@ class ScreenTargetTracking(TargetTracking, Window):
     def _start_tracking_out(self):
         super()._start_tracking_out()
         self.setup_start_tracking_out()
-        print('STOP TRACKING')
+        # print('STOP TRACKING')
         self.sync_event('CURSOR_LEAVE_TARGET')
 
     def _while_tracking_out(self):

--- a/built_in_tasks/target_tracking_task.py
+++ b/built_in_tasks/target_tracking_task.py
@@ -640,7 +640,7 @@ class ScreenTargetTracking(TargetTracking, Window):
     def _start_wait(self):
         super()._start_wait()
         self.setup_start_wait()
-        print('WAIT')
+        # print('WAIT')
 
     def _while_wait(self):
         super()._while_wait()

--- a/features/reward_features.py
+++ b/features/reward_features.py
@@ -265,17 +265,15 @@ class TrackingRewards(traits.HasTraits):
             self.reward.off()
             super().cleanup(database, saveid, **kwargs)
 
-        def _start_tracking_in(self):
-            super()._start_tracking_in()
+        def setup_start_tracking_in(self):
             self.trigger_reward = False
             self.reward.off()
             self.reward_start_frame = self.frame_index + self.tracking_reward_interval*self.fps # frame to start first reward
             self.reward_stop_frame = self.reward_start_frame + self.tracking_reward_time*self.fps # frame to stop first reward
             # print('START TRACKING', self.reward_start_frame, self.reward_stop_frame)
 
-        def _while_tracking_in(self):
-            super()._while_tracking_in()
-            # Give reward for tracking in
+        def setup_while_tracking_in(self):
+           # Give reward for tracking in
             if self.frame_index >= self.reward_start_frame and self.trigger_reward==False:
                 self.trigger_reward = True
                 self.reward_stop_frame = self.frame_index + self.tracking_reward_time*self.fps # frame to stop current reward
@@ -287,8 +285,28 @@ class TrackingRewards(traits.HasTraits):
                 self.reward.off()
                 # print('REWARD OFF', self.frame_index/self.fps)
 
+        def _start_tracking_in(self):
+            super()._start_tracking_in()
+            self.setup_start_tracking_in()
+
+        def _start_tracking_in_ramp(self):
+            super()._start_tracking_in()
+            self.setup_start_tracking_in()
+
+        def _while_tracking_in(self):
+            super()._while_tracking_in()
+            self.setup_while_tracking_in()
+
+        def _while_tracking_in_ramp(self):
+            super()._while_tracking_in()
+            self.setup_while_tracking_in()
+
         def _start_tracking_out(self):
             super()._start_tracking_out()
+            self.reward.off()
+        
+        def _start_tracking_out_ramp(self):
+            super()._start_tracking_out_ramp()
             self.reward.off()
 
 

--- a/features/reward_features.py
+++ b/features/reward_features.py
@@ -265,14 +265,14 @@ class TrackingRewards(traits.HasTraits):
             self.reward.off()
             super().cleanup(database, saveid, **kwargs)
 
-        def setup_start_tracking_in(self):
+        def general_start_tracking_in(self):
             self.trigger_reward = False
             self.reward.off()
             self.reward_start_frame = self.frame_index + self.tracking_reward_interval*self.fps # frame to start first reward
             self.reward_stop_frame = self.reward_start_frame + self.tracking_reward_time*self.fps # frame to stop first reward
             # print('START TRACKING', self.reward_start_frame, self.reward_stop_frame)
 
-        def setup_while_tracking_in(self):
+        def general_while_tracking_in(self):
            # Give reward for tracking in
             if self.frame_index >= self.reward_start_frame and self.trigger_reward==False:
                 self.trigger_reward = True
@@ -287,19 +287,19 @@ class TrackingRewards(traits.HasTraits):
 
         def _start_tracking_in(self):
             super()._start_tracking_in()
-            self.setup_start_tracking_in()
+            self.general_start_tracking_in()
 
         def _start_tracking_in_ramp(self):
-            super()._start_tracking_in()
-            self.setup_start_tracking_in()
+            super()._start_tracking_in_ramp()
+            self.general_start_tracking_in()
 
         def _while_tracking_in(self):
             super()._while_tracking_in()
-            self.setup_while_tracking_in()
+            self.general_while_tracking_in()
 
         def _while_tracking_in_ramp(self):
-            super()._while_tracking_in()
-            self.setup_while_tracking_in()
+            super()._while_tracking_in_ramp()
+            self.general_while_tracking_in()
 
         def _start_tracking_out(self):
             super()._start_tracking_out()


### PR DESCRIPTION
Fix bug that can sometimes occur when tracking rewards feature is used with ramp states. Before I hadn't perpetuated the ramp states through to the feature but now they have been incorporated and bug seems fixed.