### PR TITLE
Penalty state goes back to wait state in the target capture task

### DIFF
--- a/built_in_tasks/target_capture_task.py
+++ b/built_in_tasks/target_capture_task.py
@@ -66,12 +66,15 @@ class TargetCapture(Sequence):
         self.pause_index = 0
 
     def _start_wait(self):
+        
         if self.penalty_index == 0 and self.pause_index == 0: # doesn't call parent method when the state comes from the penalty or pause state
             # Call parent method to draw the next target capture sequence from the generator
             super()._start_wait()
+            self.tries = 0 # number of times this sequence of targets has been attempted
 
-            # number of times this sequence of targets has been attempted
-            self.tries = 0
+        if self.tries==self.max_attempts: # The task goes to the next target after the number of reattempting is max attempts 
+            super()._start_wait()
+            self.tries = 0 # number of times this sequence of targets has been attempted
 
         # index of current target presented to subject
         self.target_index = -1


### PR DESCRIPTION
Changes are as follows
1. The penalty state goes back to the wait state, but the target position doesn't change until the number of reattempting reaches the max attempt
2. Pausing the task doesn't change the target position

@mtringi I didn't change the state structure in the ready set go task, but I changed _start_wait function which is inherited in your task. I checked if the ready set go task worked. Also if you don't want to change the target position after pausing the task, please change the state structure in the same way as this PR.