### PR TITLE
online analysis for laser stim

### DIFF
--- a/analysis/online_analysis.py
+++ b/analysis/online_analysis.py
@@ -586,7 +586,7 @@ class ERPAnalysisWorker(AnalysisWorker):
     '''
     bufferlen = 5 # seconds of data to keep in the buffer
 
-    def __init__(self, task_params, data_queue, update_rate=1, time_before=0.05, 
+    def __init__(self, task_params, data_queue, update_rate=1, time_before=0.1, 
                  time_after=0.1, figure_dir='/home/aolab/figures',
                  condition_idx=None, stim_sites=None, title=None, **kwargs):
         super().__init__(task_params, data_queue, update_rate=update_rate, **kwargs)
@@ -599,6 +599,9 @@ class ERPAnalysisWorker(AnalysisWorker):
         except:
             self.condition_idx = condition_idx
         self.stim_sites = stim_sites
+        if self.condition_idx is not None and len(self.stim_sites) == 0:
+            raise ValueError('Condition index provided but no stim sites were present in the experiment')
+        self.current_condition_idx = 0
 
     def init(self):
         super().init()
@@ -607,8 +610,6 @@ class ERPAnalysisWorker(AnalysisWorker):
         self.elec_pos, self.acq_ch, _ = aopy.data.load_chmap('ECoG244')
         self.clock_dch = self.task_params.get('screen_sync_dch', 40)
         self.headstage = self.task_params.get('headstage_connector', 7)
-        self.stim_site = self.task_params.get('stim_site', None)
-        self.current_condition_idx = []
         self.clock_elapsed = 0
         self.clock_times = np.array([])
         self.trigger_dch = None
@@ -616,10 +617,6 @@ class ERPAnalysisWorker(AnalysisWorker):
         self.trigger_cycles = []
         self.trigger_times = []
         self.lfp_downsample = 25
-
-        # Determine if there are multiple conditions and which one to trigger on if so
-        if self.condition_idx is not None and len(self.stim_site) == 0:
-            raise ValueError('Condition index provided but no stim sites were present in the experiment')
 
         # Determine the trigger channel and events based on the task parameters
         if 'qwalor_trigger_dch' in self.task_params:
@@ -675,15 +672,16 @@ class ERPAnalysisWorker(AnalysisWorker):
         elec_pos, acq_ch, _ = aopy.data.load_chmap('ECoG244')
         stim_pos, stim_ch, _ = aopy.data.load_chmap('Opto32')
         for pos, ch in zip(elec_pos, acq_ch):
-            self.labels.append(aopy.visualization.annotate_spatial_map(pos, ch, 'c', 12, self.ax))
+            self.labels.append(aopy.visualization.annotate_spatial_map(pos, ch, 'c', fontsize=12, ax=self.ax))
         for pos, ch in zip(stim_pos, stim_ch):
-            self.labels.append(aopy.visualization.annotate_spatial_map(pos, ch, 'm', 12, self.ax))
+            self.labels.append(aopy.visualization.annotate_spatial_map(pos, ch, 'm', fontsize=12, ax=self.ax))
+        ax_toggle = self.fig.add_axes([0.1, 0.025, 0.1, 0.025])
+        self.toggle = Button(ax_toggle, 'Labels')
         def toggle_labels(event):
+            self.toggle.color = '0.85' if self.labels[0].get_visible() else '0.5'
             for label in self.labels:
                 label.set_visible(not label.get_visible())
         toggle_labels(None)
-        ax_toggle = self.fig.add_axes([0.1, 0.025, 0.1, 0.025])
-        self.toggle = Button(ax_toggle, 'Labels')
         self.toggle.on_clicked(toggle_labels)
 
         # Add a toggle between voltage and z-score
@@ -693,12 +691,15 @@ class ERPAnalysisWorker(AnalysisWorker):
             if self.zscore:
                 self.slider.valmax = 10
                 self.slider.set_val(5)
+                self.zscore_button.color = '0.5'
             else:
                 self.slider.valmax = 1000
                 self.slider.set_val(100)
+                self.zscore_button.color = '0.85'
         self.ax_zscore = self.fig.add_axes([0.225, 0.025, 0.1, 0.025])
         self.zscore_button = Button(self.ax_zscore, 'Z-score')
         self.zscore_button.on_clicked(toggle_zscore)
+        print('finished init')
 
     def update(self):
         super().update()
@@ -720,7 +721,7 @@ class ERPAnalysisWorker(AnalysisWorker):
         # Only count triggers that occur during the specified condition if a condition index was provided
         in_condition = True
         if self.condition_idx is not None:
-            in_condition = any(idx in self.current_condition_idx for idx in self.condition_idx)
+            in_condition = self.current_condition_idx in self.condition_idx
 
         # Append new ERPs from trigger events
         fs = self.ds.source.update_freq / self.lfp_downsample
@@ -772,7 +773,7 @@ class ERPAnalysisWorker(AnalysisWorker):
         # Update the ERP
         if erp_count == 0:
             return
-        if self.erp.shape[2] < 10: # update frequently when there are few trials
+        if self.erp.shape[2] < 50: # update frequently when there are few trials
             self._update_erp_data()
         elif self.erp.shape[2] % 10 < erp_count: # only update every 10 trials after that
             self._update_erp_data()
@@ -780,7 +781,7 @@ class ERPAnalysisWorker(AnalysisWorker):
     def _update_erp_data(self):
         fs = self.ds.source.update_freq / self.lfp_downsample
         if self.zscore:
-            altcond_window = (0, self.time_after), 
+            altcond_window = (0, self.time_after)
             nullcond_window = (-self.time_before, 0)
             altcond, nullcond = aopy.analysis.latency.prepare_erp(self.erp, self.erp, fs, 
                                                                 self.time_before, self.time_after, 
@@ -1036,10 +1037,14 @@ class OnlineDataServer(threading.Thread):
 
         # Is there ecube neural data?
         if 'record_headstage' in self.task_params and self.task_params['record_headstage']:
-            stim_site = self.task_params.get('stim_site', None)
+            stim_site = self.task_params.get('stimulation_site', None)
             if stim_site is None:
+                # data_queue = mp.Queue()
+                # self.analysis_workers.append((ERPAnalysisWorker(self.task_params, data_queue), data_queue))
                 data_queue = mp.Queue()
-                self.analysis_workers.append((ERPAnalysisWorker(self.task_params, data_queue), data_queue))
+                self.analysis_workers.append((SLICAnalysisWorker(
+                    self.task_params, data_queue, condition_idx=idx, stim_sites=stim_sites, title=title
+                    ), data_queue))
             else:
                 try:
                     stim_sites = [int(stim_site)]
@@ -1048,16 +1053,17 @@ class OnlineDataServer(threading.Thread):
                 for idx, site in enumerate(stim_sites):
                     if site == -1:
                         continue
+                    print('Adding ERP and SLIC workers for stim site', site)
                     title = f"Stim site {site}"
                     data_queue = mp.Queue()
                     self.analysis_workers.append((ERPAnalysisWorker(
                         self.task_params, data_queue, condition_idx=idx, stim_sites=stim_sites, 
                         title=title), data_queue))
-                    title = f"SLIC Stim site {site}"
-                    data_queue = mp.Queue()
-                    self.analysis_workers.append((SLICAnalysisWorker(
-                        self.task_params, data_queue, condition_idx=idx, time_before=0.25, time_after=0.25, 
-                        stim_sites=stim_sites, title=title), data_queue))
+                    # title = f"SLIC Stim site {site}"
+                    # data_queue = mp.Queue()
+                    # self.analysis_workers.append((SLICAnalysisWorker(
+                    #     self.task_params, data_queue, condition_idx=[idx], stim_sites=stim_sites, 
+                    #     title=title), data_queue))
 
         # Is this a BMI task?
         if 'decoder' in self.task_params:
@@ -1127,7 +1133,7 @@ if __name__ == '__main__':
         hostname = 'localhost'
     
     if len(sys.argv) >= 3:
-        port = sys.argv[2]
+        port = int(sys.argv[2])
     else:
         port = 5000
 
@@ -1136,10 +1142,10 @@ if __name__ == '__main__':
     else:
         display = ':0'
 
-    # Spin up servernode
-    if hostname == '0.0.0.0':
-        import subprocess
-        subprocess.Popen('/home/aolab/code/bmi3d/riglib/ecube/servernode-control')
+    # # Spin up servernode
+    # if hostname == '0.0.0.0':
+    #     import subprocess
+    #     subprocess.Popen('/home/aolab/code/bmi3d/riglib/ecube/servernode-control')
 
     # Start server
     print(hostname, port, display)

--- a/analysis/online_analysis.py
+++ b/analysis/online_analysis.py
@@ -113,7 +113,7 @@ class AnalysisWorker(mp.Process):
         plt.pause(0.1)
 
         t_update = time.perf_counter()
-        while not self._stop_event.is_set():
+        while plt.fignum_exists(self.fig.number) and (not self._stop_event.is_set()):
             if time.perf_counter() - t_update > 1./self.update_rate:
                 try:
                     self.update()
@@ -617,6 +617,7 @@ class ERPAnalysisWorker(AnalysisWorker):
         self.trigger_cycles = []
         self.trigger_times = []
         self.lfp_downsample = 25
+        self.erp_since_update = 0
 
         # Determine the trigger channel and events based on the task parameters
         if 'qwalor_trigger_dch' in self.task_params:
@@ -696,10 +697,13 @@ class ERPAnalysisWorker(AnalysisWorker):
                 self.slider.valmax = 1000
                 self.slider.set_val(100)
                 self.zscore_button.color = '0.85'
+            self.slider.ax.set_xlim(self.slider.valmin, self.slider.valmax)
+            self._update_erp_data()
+            self.draw()
+
         self.ax_zscore = self.fig.add_axes([0.225, 0.025, 0.1, 0.025])
         self.zscore_button = Button(self.ax_zscore, 'Z-score')
         self.zscore_button.on_clicked(toggle_zscore)
-        print('finished init')
 
     def update(self):
         super().update()
@@ -771,14 +775,16 @@ class ERPAnalysisWorker(AnalysisWorker):
         self.clock_elapsed = clock_elapsed_new
 
         # Update the ERP
-        if erp_count == 0:
-            return
-        if self.erp.shape[2] < 50: # update frequently when there are few trials
-            self._update_erp_data()
-        elif self.erp.shape[2] % 10 < erp_count: # only update every 10 trials after that
-            self._update_erp_data()
+        self.erp_since_update += erp_count
+        self._update_erp_data()
 
     def _update_erp_data(self):
+        if self.erp_since_update == 0:
+            return
+        if (self.erp.shape[2] > 50) and (self.erp_since_update < 10):
+            return  # only update the plot every 10 new ERPs to save on computation
+        self.erp_since_update = 0
+        
         fs = self.ds.source.update_freq / self.lfp_downsample
         if self.zscore:
             altcond_window = (0, self.time_after)
@@ -801,9 +807,9 @@ class ERPAnalysisWorker(AnalysisWorker):
             if event_name in self.trigger_events:
                 self.trigger_cycles.append(self.cycle_count)
         elif key == 'laser_conditions': # multiple lasers on each trial
-            self.current_condition_idx = values[0]
+            self.current_condition_idx = values[0][0] # pick first one for now, TODO: support multiple conditions at once
         elif key == 'laser_condition': # single laser on each trial
-            self.current_condition_idx = [values[0]]
+            self.current_condition_idx = values[0]
 
     def draw(self):
         super().draw()
@@ -839,23 +845,29 @@ class SLICAnalysisWorker(ERPAnalysisWorker):
         _, acq_ch, _ = aopy.data.load_chmap('ECoG244')
         self.stim_ch = np.where(np.isin(acq_ch, ch_near_stim))[0]
         self.taper_len = 0.06
+        self.angle_map = self.data_map.copy()
+        self.slic_map = self.data_map.copy()
 
         # Add a toggle between coherence and phase
-        self.ax_zscore.set_visible(False) # hide the z-score button
+        del self.zscore_button # hide the z-score button
         self.show_angle = False
-        self.slic_map = np.zeros((16,16))
-        self.data_map = self.slic_map
+        self.slider.valmin = 0
+        self.slider.valmax = 1
+        self.slider.set_val(0.1)
+        self.slider.ax.set_xlim(self.slider.valmin, self.slider.valmax)
         def toggle_angle(event):
             self.show_angle = not self.show_angle
             if self.show_angle:
-                self.data_map = self.angle_map
                 self.erp_im.set_cmap('YlGnBu')
                 self.erp_im.set_clim=(0, 2*np.pi),
+                self.slider.drag_active = False # disable the slider for phase
             else:
-                self.data_map = self.slic_map
                 self.erp_im.set_cmap('bwr')
                 self.erp_im.set_clim=(-self.slider.val, self.slider.val), 
                 self.erp_im.set_data(self.data_map)
+                self.slider.drag_active = True
+            self.draw()
+
         self.ax_angle = self.fig.add_axes([0.225, 0.025, 0.1, 0.025])
         self.angle_button = Button(self.ax_angle, 'Phase')
         self.angle_button.on_clicked(toggle_angle)
@@ -874,14 +886,21 @@ class SLICAnalysisWorker(ERPAnalysisWorker):
                 self.band[1] = hf
             except:
                 pass
-        axlf = self.fig.add_axes([0.525, 0.025, 0.2, 0.025])
+        axlf = self.fig.add_axes([0.525, 0.025, 0.05, 0.025])
         self.lf_text = TextBox(axlf, 'Min freq (Hz)', initial='80')
         self.lf_text.on_submit(on_lf_text_submit)
-        axhf = self.fig.add_axes([0.725, 0.025, 0.2, 0.025])
+        axhf = self.fig.add_axes([0.725, 0.025, 0.05, 0.025])
         self.hf_text = TextBox(axhf, 'Max freq (Hz)', initial='150')
         self.hf_text.on_submit(on_hf_text_submit)
+        print('finished init')
 
     def _update_erp_data(self):
+        if self.erp_since_update == 0:
+            return
+        if (self.erp_since_update < 10):
+            return  # only update the plot every 10 new ERPs to save on computation
+        self.erp_since_update = 0
+
         fs = self.ds.source.update_freq / self.lfp_downsample
         freqs, time, coh_all, angle_all = aopy.analysis.connectivity.calc_connectivity_map_coh(
             self.erp, fs, self.time_before, self.time_after, self.stim_ch, 
@@ -892,6 +911,13 @@ class SLICAnalysisWorker(ERPAnalysisWorker):
         self.angle_map = aopy.visualization.get_data_map(angle, self.elec_pos[:,0], self.elec_pos[:,1])
         slic = aopy.analysis.calc_tfr_mean(freqs, time[1:], coh_all[:,[1],:]-coh_all[:,[0],:], self.band)
         self.slic_map = aopy.visualization.get_data_map(slic, self.elec_pos[:,0], self.elec_pos[:,1])
+
+    def draw(self):
+        if self.show_angle:
+            self.data_map = self.angle_map
+        else:
+            self.data_map = self.slic_map
+        super().draw()
 
 
 class BMIAnalysisWorker(AnalysisWorker):
@@ -1037,33 +1063,24 @@ class OnlineDataServer(threading.Thread):
 
         # Is there ecube neural data?
         if 'record_headstage' in self.task_params and self.task_params['record_headstage']:
-            stim_site = self.task_params.get('stimulation_site', None)
-            if stim_site is None:
-                # data_queue = mp.Queue()
-                # self.analysis_workers.append((ERPAnalysisWorker(self.task_params, data_queue), data_queue))
+            stim_site = self.task_params.get('stimulation_site', 0)
+            try:
+                stim_sites = [int(stim_site)]
+            except:
+                stim_sites = [int(s) for s in stim_site]
+            for idx, site in enumerate(stim_sites):
+                if site == -1:
+                    continue
+                title = f"Stim site {site}"
+                data_queue = mp.Queue()
+                self.analysis_workers.append((ERPAnalysisWorker(
+                    self.task_params, data_queue, condition_idx=idx, stim_sites=stim_sites, 
+                    title=title), data_queue))
+                title = f"SLIC Stim site {site}"
                 data_queue = mp.Queue()
                 self.analysis_workers.append((SLICAnalysisWorker(
-                    self.task_params, data_queue, condition_idx=idx, stim_sites=stim_sites, title=title
-                    ), data_queue))
-            else:
-                try:
-                    stim_sites = [int(stim_site)]
-                except:
-                    stim_sites = [int(s) for s in stim_site]
-                for idx, site in enumerate(stim_sites):
-                    if site == -1:
-                        continue
-                    print('Adding ERP and SLIC workers for stim site', site)
-                    title = f"Stim site {site}"
-                    data_queue = mp.Queue()
-                    self.analysis_workers.append((ERPAnalysisWorker(
-                        self.task_params, data_queue, condition_idx=idx, stim_sites=stim_sites, 
-                        title=title), data_queue))
-                    # title = f"SLIC Stim site {site}"
-                    # data_queue = mp.Queue()
-                    # self.analysis_workers.append((SLICAnalysisWorker(
-                    #     self.task_params, data_queue, condition_idx=[idx], stim_sites=stim_sites, 
-                    #     title=title), data_queue))
+                    self.task_params, data_queue, condition_idx=idx, stim_sites=stim_sites, 
+                    title=title), data_queue))
 
         # Is this a BMI task?
         if 'decoder' in self.task_params:

--- a/analysis/online_analysis.py
+++ b/analysis/online_analysis.py
@@ -606,6 +606,7 @@ class ERPAnalysisWorker(AnalysisWorker):
         # Initialize the data source
         self.elec_pos, self.acq_ch, _ = aopy.data.load_chmap('ECoG244')
         self.clock_dch = self.task_params.get('screen_sync_dch', 40)
+        self.headstage = self.task_params.get('headstage_connector', 7)
         self.stim_site = self.task_params.get('stim_site', None)
         self.current_condition_idx = []
         self.clock_elapsed = 0
@@ -626,6 +627,7 @@ class ERPAnalysisWorker(AnalysisWorker):
             channels = map_channels_for_multisource(headstage_channels=self.acq_ch, 
                                                          digital_channels=[self.clock_dch, self.trigger_dch])
             print('Triggering on qwalor channel', self.trigger_dch)
+            print('Using clock channel', self.clock_dch)
         elif 'qwalor_ch1_enable' in self.task_params: # TODO: support multiple lasers
             for idx in range(1,5):
                 if self.task_params[f'qwalor_ch{idx}_enable']:
@@ -634,11 +636,13 @@ class ERPAnalysisWorker(AnalysisWorker):
             channels = map_channels_for_multisource(headstage_channels=self.acq_ch,
                                                             digital_channels=[self.clock_dch, self.trigger_dch])
             print('Triggering on qwalor channel', self.trigger_dch)
+            print('Using clock channel', self.clock_dch)
         else:
             self.trigger_events.append('TARGET_ON') # For flash
             channels = map_channels_for_multisource(headstage_channels=self.acq_ch, digital_channels=[self.clock_dch])
             print('Triggering on events', self.trigger_events)
-        self.ds = MultiChanDataSource(MultiSource, channels=channels, bufferlen=self.bufferlen)
+            print('Using clock channel', self.clock_dch)
+        self.ds = MultiChanDataSource(MultiSource, channels=channels, bufferlen=self.bufferlen, headstage=self.headstage)
         self.ds.start()
         print('datasource started')
 
@@ -968,7 +972,8 @@ class OnlineDataServer(threading.Thread):
             MultiSource.pre_init()
             print('eCube streaming initialized')
         except:
-            pass
+            print('Error initializing eCube streaming')
+            traceback.print_exc()
 
         # Initialize the server
         self._stop_event = threading.Event()
@@ -1132,9 +1137,9 @@ if __name__ == '__main__':
         display = ':0'
 
     # Spin up servernode
-    # if hostname == '0.0.0.0':
-    #     import subprocess
-    #     subprocess.Popen('/home/aolab/code/bmi3d/riglib/ecube/servernode-control')
+    if hostname == '0.0.0.0':
+        import subprocess
+        subprocess.Popen('/home/aolab/code/bmi3d/riglib/ecube/servernode-control')
 
     # Start server
     print(hostname, port, display)

--- a/analysis/online_analysis.py
+++ b/analysis/online_analysis.py
@@ -11,8 +11,10 @@ import traceback
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.collections import PatchCollection
-from matplotlib.widgets import Button, Slider, Cursor
+from matplotlib.widgets import Button, Slider, Cursor, TextBox
 import aopy
+import traits
+from traits.trait_types import self
 from riglib.ecube import MultiSource, map_channels_for_multisource
 from riglib.source import MultiChanDataSource
 
@@ -585,11 +587,18 @@ class ERPAnalysisWorker(AnalysisWorker):
     bufferlen = 5 # seconds of data to keep in the buffer
 
     def __init__(self, task_params, data_queue, update_rate=1, time_before=0.05, 
-                 time_after=0.1, figure_dir='/home/aolab/figures', **kwargs):
+                 time_after=0.1, figure_dir='/home/aolab/figures',
+                 condition_idx=None, stim_sites=None, title=None, **kwargs):
         super().__init__(task_params, data_queue, update_rate=update_rate, **kwargs)
         self.time_before = time_before
         self.time_after = time_after
         self.figure_dir = figure_dir
+        self.title = title
+        try:
+            self.condition_idx = [int(condition_idx)]
+        except:
+            self.condition_idx = condition_idx
+        self.stim_sites = stim_sites
 
     def init(self):
         super().init()
@@ -597,6 +606,8 @@ class ERPAnalysisWorker(AnalysisWorker):
         # Initialize the data source
         self.elec_pos, self.acq_ch, _ = aopy.data.load_chmap('ECoG244')
         self.clock_dch = self.task_params.get('screen_sync_dch', 40)
+        self.stim_site = self.task_params.get('stim_site', None)
+        self.current_condition_idx = []
         self.clock_elapsed = 0
         self.clock_times = np.array([])
         self.trigger_dch = None
@@ -605,13 +616,28 @@ class ERPAnalysisWorker(AnalysisWorker):
         self.trigger_times = []
         self.lfp_downsample = 25
 
+        # Determine if there are multiple conditions and which one to trigger on if so
+        if self.condition_idx is not None and len(self.stim_site) == 0:
+            raise ValueError('Condition index provided but no stim sites were present in the experiment')
+
+        # Determine the trigger channel and events based on the task parameters
         if 'qwalor_trigger_dch' in self.task_params:
             self.trigger_dch = self.task_params['qwalor_trigger_dch']
             channels = map_channels_for_multisource(headstage_channels=self.acq_ch, 
                                                          digital_channels=[self.clock_dch, self.trigger_dch])
+            print('Triggering on qwalor channel', self.trigger_dch)
+        elif 'qwalor_ch1_enable' in self.task_params: # TODO: support multiple lasers
+            for idx in range(1,5):
+                if self.task_params[f'qwalor_ch{idx}_enable']:
+                    self.trigger_dch = self.task_params[f'qwalor_ch{idx}_trigger_dch']
+                    break
+            channels = map_channels_for_multisource(headstage_channels=self.acq_ch,
+                                                            digital_channels=[self.clock_dch, self.trigger_dch])
+            print('Triggering on qwalor channel', self.trigger_dch)
         else:
             self.trigger_events.append('TARGET_ON') # For flash
             channels = map_channels_for_multisource(headstage_channels=self.acq_ch, digital_channels=[self.clock_dch])
+            print('Triggering on events', self.trigger_events)
         self.ds = MultiChanDataSource(MultiSource, channels=channels, bufferlen=self.bufferlen)
         self.ds.start()
         print('datasource started')
@@ -626,6 +652,8 @@ class ERPAnalysisWorker(AnalysisWorker):
                                                  cmap='bwr', ax=self.ax)
         self.erp_im.set_clim(-100, 100)
         self.erp_text = self.ax.text(0.75, 1.05, '.', ha='center', va='center', fontsize=12, transform=self.ax.transAxes)
+        if self.title is not None:
+            self.ax.set_title(self.title)
 
         # Add a slider to control the range
         ax_slider = self.fig.add_axes([0.225, 0.075, 0.6, 0.03])
@@ -654,6 +682,20 @@ class ERPAnalysisWorker(AnalysisWorker):
         self.toggle = Button(ax_toggle, 'Labels')
         self.toggle.on_clicked(toggle_labels)
 
+        # Add a toggle between voltage and z-score
+        self.zscore = False
+        def toggle_zscore(event):
+            self.zscore = not self.zscore
+            if self.zscore:
+                self.slider.valmax = 10
+                self.slider.set_val(5)
+            else:
+                self.slider.valmax = 1000
+                self.slider.set_val(100)
+        self.ax_zscore = self.fig.add_axes([0.225, 0.025, 0.1, 0.025])
+        self.zscore_button = Button(self.ax_zscore, 'Z-score')
+        self.zscore_button.on_clicked(toggle_zscore)
+
     def update(self):
         super().update()
         # Keep track of clock cycles
@@ -671,27 +713,36 @@ class ERPAnalysisWorker(AnalysisWorker):
             timestamps, edges = aopy.utils.detect_edges(trigger_data, self.ds.source.update_freq, rising=True, falling=False)   
             self.trigger_times = np.concatenate((self.trigger_times, timestamps + clock_elapsed_prev)).tolist()
 
+        # Only count triggers that occur during the specified condition if a condition index was provided
+        in_condition = True
+        if self.condition_idx is not None:
+            in_condition = any(idx in self.current_condition_idx for idx in self.condition_idx)
+
         # Append new ERPs from trigger events
         fs = self.ds.source.update_freq / self.lfp_downsample
         nt = 2./self.update_rate # seconds
         npts = int(nt * self.ds.source.update_freq)
         lfp = self.ds.get(npts, map_channels_for_multisource(headstage_channels=self.acq_ch))
         lfp = np.array(lfp)[:,::self.lfp_downsample].T # reshape and downsample (nt, nch)
+        erp_count = 0
         ignored_trigger_cycles = []
         while len(self.trigger_cycles) > 0:
             cycle = self.trigger_cycles.pop()
             if cycle >= len(self.clock_times):
-                ignored_trigger_cycles.append(cycle)
+                ignored_trigger_cycles.append(cycle) # future cycle we haven't seen yet, check back on the next update
                 continue
             time = self.clock_times[cycle]
             if time + self.time_after > clock_elapsed_new:
-                ignored_trigger_cycles.append(cycle)
+                ignored_trigger_cycles.append(cycle) # future trigger we haven't seen yet, check back on the next update
                 continue
             elif time - self.time_before < clock_elapsed_new - nt:
-                print('missed cycle', cycle, 'at time', time)
+                print('missed cycle', cycle, 'at time', time) # missed trigger we don't have any data for, just skip it
                 continue
+            if not in_condition:
+                continue # trigger occurred outside of the specified condition, ignore it
             erp = aopy.analysis.calc_erp(lfp, [time - clock_elapsed_new + nt], self.time_before, self.time_after, fs)
             self.erp = np.concatenate((self.erp, erp), axis=2)
+            erp_count += 1
         self.trigger_cycles = ignored_trigger_cycles
 
         # Check for new digital triggers
@@ -699,22 +750,44 @@ class ERPAnalysisWorker(AnalysisWorker):
         while len(self.trigger_times) > 0:
             time = self.trigger_times.pop()
             if time + self.time_after > clock_elapsed_new:
-                ignored_trigger_times.append(time)
+                ignored_trigger_times.append(time) # future trigger we haven't seen yet, check back on the next update
                 continue
             elif time - self.time_before < clock_elapsed_new - nt:
-                print('missed trigger', time)
+                print('missed trigger', time) # missed trigger we don't have any data for, just skip it
                 continue
+            if not in_condition:
+                continue # trigger occurred outside of the specified condition, ignore it
             erp = aopy.analysis.calc_erp(lfp, [time - clock_elapsed_new + nt], self.time_before, self.time_after, fs)
             self.erp = np.concatenate((self.erp, erp), axis=2)
+            erp_count += 1
         self.trigger_times = ignored_trigger_times
 
         # Update the total elapsed time
         self.clock_elapsed = clock_elapsed_new
 
         # Update the ERP
+        if erp_count == 0:
+            return
+        if self.erp.shape[2] < 10: # update frequently when there are few trials
+            self._update_erp_data()
+        elif self.erp.shape[2] % 10 < erp_count: # only update every 10 trials after that
+            self._update_erp_data()
+
+    def _update_erp_data(self):
         fs = self.ds.source.update_freq / self.lfp_downsample
-        max_erp = aopy.analysis.get_max_erp(self.erp, self.time_before, self.time_after, fs, trial_average=True)
-        self.data_map = aopy.visualization.get_data_map(max_erp*1.907348633e-7*1e6, self.elec_pos[:,0], self.elec_pos[:,1])
+        if self.zscore:
+            altcond_window = (0, self.time_after), 
+            nullcond_window = (-self.time_before, 0)
+            altcond, nullcond = aopy.analysis.latency.prepare_erp(self.erp, self.erp, fs, 
+                                                                self.time_before, self.time_after, 
+                                                                nullcond_window, altcond_window)[:2]
+            z_erp = np.std(nullcond, axis=0)
+            sd_erp = (altcond - np.mean(nullcond, axis=0)) / z_erp
+            max_erp = aopy.analysis.get_max_erp(sd_erp, 0, self.time_after, fs, trial_average=True)
+        else:
+            max_erp = aopy.analysis.get_max_erp(self.erp, self.time_before, self.time_after, fs, trial_average=True)
+            max_erp *= 1.907348633e-7*1e6 # convert to microvolts
+        self.data_map = aopy.visualization.get_data_map(max_erp, self.elec_pos[:,0], self.elec_pos[:,1])
 
     def handle_data(self, key, values):
         super().handle_data(key, values)
@@ -722,6 +795,10 @@ class ERPAnalysisWorker(AnalysisWorker):
             event_name, event_data = values
             if event_name in self.trigger_events:
                 self.trigger_cycles.append(self.cycle_count)
+        elif key == 'laser_conditions': # multiple lasers on each trial
+            self.current_condition_idx = values[0]
+        elif key == 'laser_condition': # single laser on each trial
+            self.current_condition_idx = [values[0]]
 
     def draw(self):
         super().draw()
@@ -733,15 +810,84 @@ class ERPAnalysisWorker(AnalysisWorker):
         Cleanup tasks after the experiment ends, e.g. saving the figure.
         '''
         self.ds.stop()      
-        # TO-DO: implenent saving figures
         subject = self.task_params.get('subject_name', 'None')
         te_id = self.task_params.get('te_id', 'None')
         if te_id == 'None':
             return
         date = datetime.date.today()
-        filename = f'online_erp_{subject}_{te_id}_{date}.png'
+        if self.title is not None:
+            filename = f'online_erp_{self.title.replace(" ", "_")}_{subject}_{te_id}_{date}.png'
+        else:
+            filename = f'online_erp_{subject}_{te_id}_{date}.png'
         plt.figure(self.fig)
         aopy.visualization.savefig(self.figure_dir, filename, transparent=False)
+
+class SLICAnalysisWorker(ERPAnalysisWorker):
+    '''
+    Plots SLIC connectivity from experiments with an ECoG244 array recordings.
+    '''
+    def init(self):
+        super().init()
+        self.erp_im.set_clim(-0.1, 0.1)
+        stim_site = self.stim_sites[self.condition_idx[0]]
+        ch_near_stim = aopy.analysis.connectivity.get_acq_ch_near_stimulation_site(stim_site)
+        _, acq_ch, _ = aopy.data.load_chmap('ECoG244')
+        self.stim_ch = np.where(np.isin(acq_ch, ch_near_stim))[0]
+        self.taper_len = 0.06
+
+        # Add a toggle between coherence and phase
+        self.ax_zscore.set_visible(False) # hide the z-score button
+        self.show_angle = False
+        self.slic_map = np.zeros((16,16))
+        self.data_map = self.slic_map
+        def toggle_angle(event):
+            self.show_angle = not self.show_angle
+            if self.show_angle:
+                self.data_map = self.angle_map
+                self.erp_im.set_cmap('YlGnBu')
+                self.erp_im.set_clim=(0, 2*np.pi),
+            else:
+                self.data_map = self.slic_map
+                self.erp_im.set_cmap('bwr')
+                self.erp_im.set_clim=(-self.slider.val, self.slider.val), 
+                self.erp_im.set_data(self.data_map)
+        self.ax_angle = self.fig.add_axes([0.225, 0.025, 0.1, 0.025])
+        self.angle_button = Button(self.ax_angle, 'Phase')
+        self.angle_button.on_clicked(toggle_angle)
+
+        # Add text boxes to enter the frequency band of interest
+        self.band = [80, 150]
+        def on_lf_text_submit(text):
+            try:
+                lf = float(text)
+                self.band[0] = lf
+            except:
+                pass
+        def on_hf_text_submit(text):
+            try:
+                hf = float(text)
+                self.band[1] = hf
+            except:
+                pass
+        axlf = self.fig.add_axes([0.525, 0.025, 0.2, 0.025])
+        self.lf_text = TextBox(axlf, 'Min freq (Hz)', initial='80')
+        self.lf_text.on_submit(on_lf_text_submit)
+        axhf = self.fig.add_axes([0.725, 0.025, 0.2, 0.025])
+        self.hf_text = TextBox(axhf, 'Max freq (Hz)', initial='150')
+        self.hf_text.on_submit(on_hf_text_submit)
+
+    def _update_erp_data(self):
+        fs = self.ds.source.update_freq / self.lfp_downsample
+        freqs, time, coh_all, angle_all = aopy.analysis.connectivity.calc_connectivity_map_coh(
+            self.erp, fs, self.time_before, self.time_after, self.stim_ch, 
+            window=(-self.taper_len,self.taper_len), n=self.taper_len, step=self.taper_len, 
+            parallel=False, verbose=False
+        )
+        angle = aopy.analysis.calc_tfr_mean(freqs, time[1:], angle_all[:,[1],:], self.band)
+        self.angle_map = aopy.visualization.get_data_map(angle, self.elec_pos[:,0], self.elec_pos[:,1])
+        slic = aopy.analysis.calc_tfr_mean(freqs, time[1:], coh_all[:,[1],:]-coh_all[:,[0],:], self.band)
+        self.slic_map = aopy.visualization.get_data_map(slic, self.elec_pos[:,0], self.elec_pos[:,1])
+
 
 class BMIAnalysisWorker(AnalysisWorker):
     '''
@@ -859,7 +1005,7 @@ class OnlineDataServer(threading.Thread):
         Once the experiment is initialized but before it starts, we spin up the analysis processes
         based on what kind of experiment is running.
         '''
-        # Always start with the behavior analysis worker
+        # Open the behavior analysis worker
         print('init in state', self.state)
         data_queue = mp.Queue()
         if self.task_params['experiment_name'] == 'ManualControl':
@@ -885,8 +1031,28 @@ class OnlineDataServer(threading.Thread):
 
         # Is there ecube neural data?
         if 'record_headstage' in self.task_params and self.task_params['record_headstage']:
-            data_queue = mp.Queue()
-            self.analysis_workers.append((ERPAnalysisWorker(self.task_params, data_queue), data_queue))
+            stim_site = self.task_params.get('stim_site', None)
+            if stim_site is None:
+                data_queue = mp.Queue()
+                self.analysis_workers.append((ERPAnalysisWorker(self.task_params, data_queue), data_queue))
+            else:
+                try:
+                    stim_sites = [int(stim_site)]
+                except:
+                    stim_sites = [int(s) for s in stim_site]
+                for idx, site in enumerate(stim_sites):
+                    if site == -1:
+                        continue
+                    title = f"Stim site {site}"
+                    data_queue = mp.Queue()
+                    self.analysis_workers.append((ERPAnalysisWorker(
+                        self.task_params, data_queue, condition_idx=idx, stim_sites=stim_sites, 
+                        title=title), data_queue))
+                    title = f"SLIC Stim site {site}"
+                    data_queue = mp.Queue()
+                    self.analysis_workers.append((SLICAnalysisWorker(
+                        self.task_params, data_queue, condition_idx=idx, time_before=0.25, time_after=0.25, 
+                        stim_sites=stim_sites, title=title), data_queue))
 
         # Is this a BMI task?
         if 'decoder' in self.task_params:

--- a/features/debug_features.py
+++ b/features/debug_features.py
@@ -114,9 +114,21 @@ class OnlineAnalysis(traits.HasTraits):
         if hasattr(self, 'targs') and hasattr(self, 'gen_indices'):
             for i in range(len(self.targs)):
                 self._send_online_analysis_msg('target_location', self.gen_indices[i], self.targs[i])
+        
+        # Eye / hand sequence trial information
         if hasattr(self, 'is_sequence'):
             self._send_online_analysis_msg('is_sequence', self.is_sequence)
             
+    def _parse_next_trial(self):
+        if hasattr(super(), '_parse_next_trial'):
+            super()._parse_next_trial()
+
+        # Laser conditions
+        if hasattr(self, 'trial_index') and hasattr(self, 'laser_powers'):
+            self._send_online_analysis_msg('laser_conditions', self.trial_index, self.laser_powers)
+        if hasattr(self, 'laser_power') and hasattr(self, 'laser_index'):
+            self._send_online_analysis_msg('laser_condition', self.laser_index, self.laser_power)
+        
     def _cycle(self):
         '''
         Send cursor and eye position data to the online analysis server

--- a/features/ecube_features.py
+++ b/features/ecube_features.py
@@ -174,7 +174,7 @@ class RecordECube(traits.HasTraits):
                 print(e)
                 traceback.print_exc()
                 log_exception(e)
-                cls.ecube_status = "Could not connect to eCube. Make sure servernode is running!\n"
+                cls.ecube_status = "Could not connect to eCube. Make sure servernode is running!\n" + str(e)
         if hasattr(super(), 'pre_init'):
             super().pre_init(saveid=saveid, **kwargs)
 

--- a/riglib/ecube/__init__.py
+++ b/riglib/ecube/__init__.py
@@ -466,10 +466,7 @@ class MultiSource(DataSourceSystem):
         print('...started!')
     
     def stop(self):
-
-        # Stop streaming
-        if not self.conn.stop():
-            del self.conn # try to force the streaming to end by deleting the ecube connection object
+        del self.conn # try to force the streaming to end by deleting the ecube connection object
         
     def get(self):
         '''

--- a/riglib/ecube/__init__.py
+++ b/riglib/ecube/__init__.py
@@ -416,23 +416,22 @@ class MultiSource(DataSourceSystem):
     dtype = np.dtype('float')
 
     @classmethod
-    def pre_init(cls, headstage=7, n_digital_channels=64, n_analog_channels=32, n_headstage_channels=256):
+    def pre_init(cls, n_digital_channels=64, n_analog_channels=32, n_headstage_channels=256):
         '''
         Set up servernode with all the possible channels you want to use
         '''
         conn = eCubeStream(autoshutdown=False, debug=True)
 
         # Remove all existing sources
-        subscribed = conn.listadded()
-        if len(subscribed[0]) > 0:
-            conn.remove(('Headstages', headstage))
-        if len(subscribed[1]) > 0:
-            conn.remove(('AnalogPanel',))
-        if len(subscribed[2]) > 0:
-            conn.remove(('DigitalPanel',))
+        conn.remove([('Headstages', i) for i in range(1,11)])
+        conn.remove(('AnalogPanel',))
+        conn.remove(('DigitalPanel',))
 
         # Add all available channels
-        conn.add(('Headstages', headstage, (1, n_headstage_channels)))
+        available = conn.listavailable()
+        available_hs = np.where(available[0] >= n_headstage_channels)[0] + 1
+        print(available_hs)
+        conn.add([('Headstages', int(i), (1, n_headstage_channels)) for i in available_hs])
         conn.add(('AnalogPanel', (1, n_analog_channels)))
         conn.add(('DigitalPanelAsChans', (1, n_digital_channels)))
 

--- a/riglib/ecube/__init__.py
+++ b/riglib/ecube/__init__.py
@@ -429,11 +429,13 @@ class MultiSource(DataSourceSystem):
 
         # Add all available channels
         available = conn.listavailable()
-        available_hs = np.where(available[0] >= n_headstage_channels)[0] + 1
-        print(available_hs)
-        conn.add([('Headstages', int(i), (1, n_headstage_channels)) for i in available_hs])
         conn.add(('AnalogPanel', (1, n_analog_channels)))
         conn.add(('DigitalPanelAsChans', (1, n_digital_channels)))
+
+        # Add available headstage channels
+        available_hs = np.where(available[0] >= n_headstage_channels)[0] + 1
+        if len(available_hs) > 0:
+            conn.add([('Headstages', int(i), (1, n_headstage_channels)) for i in available_hs])
 
         subscribed = conn.listadded() # in debug mode this prints out the added channels
 

--- a/riglib/ecube/pyeCubeStream.py
+++ b/riglib/ecube/pyeCubeStream.py
@@ -471,7 +471,7 @@ class eCubeStream:
 
         self.ctlsock.send_multipart([self.VERSTR, b"START"])
         reply = self.ctlsock.recv_multipart()
-        if len(reply) == 1 and reply[0] != b"OKSTART":
+        if len(reply) == 1 and reply[0] != b"OKSTART" and reply[0] != b"The acquisition is already running":
             raise RuntimeError(reply[0].decode('utf-8'))
 
         self.isstreaming = True

--- a/tests/test_online_analysis.py
+++ b/tests/test_online_analysis.py
@@ -87,7 +87,7 @@ class TestOnlineAnalysis(unittest.TestCase):
             targets[trial_num][0].append(trial['index'])
             targets[trial_num][1].append(trial['target'])
         cursor = task['cursor']
-        eye = task['eye']
+        eye = task['eye'][:,:2]
 
         # Start exp 1
         os.environ['DISPLAY'] = ':0.0'


### PR DESCRIPTION
change online analysis to display one evoked response map per stimulation site
also add the ability to compute connectivity from stimulation data

minor fixes
- any headstage not just 7
- add z-score option for ERP
- stop analysis once windows are closed
- don't update ERP on every new event to avoid overloading cpu
- add exception information to ecube errors