### PR TITLE
Sofie fix saccade task

### DIFF
--- a/built_in_tasks/target_capture_task_eye.py
+++ b/built_in_tasks/target_capture_task_eye.py
@@ -1924,7 +1924,7 @@ class ScreenTargetCapture_Saccade(ScreenTargetCapture):
         super()._start_wait()
         # Make cursor invisible
         self.plant.cursor.detach()
-        self.chain_length = 2
+        self.chain_length = len(self.targs)
         
     def _test_enter_target(self, ts):
         '''

--- a/features/eyetracker_features.py
+++ b/features/eyetracker_features.py
@@ -78,15 +78,24 @@ class EyeCalibration(traits.HasTraits):
                 # load raw eye data
                 # raw_eye_data, raw_eye_metadata = aopy.preproc.parse_oculomatic(hdf_dir, files, debug=False)
                 samplerate = 1000
-                eye_interp = aopy.data.get_interp_kinematics(bmi3d_data, bmi3d_metadata, datatype='eye',
+                try:
+                    eye_interp = aopy.data.get_interp_kinematics(bmi3d_data, bmi3d_metadata, datatype='eye',
+                                                            samplerate=samplerate)[:,:4]
+                except:
+                    eye_interp = aopy.data.bmi3d.get_interp_task_data(bmi3d_data, bmi3d_metadata, datatype='eye',
                                                             samplerate=samplerate)[:,:4]
 
                 # calculate coefficients to calibrate eye data
                 events = bmi3d_data['events']
 
                 if not self.eye_target_calibration:
-                    cursor_interp = aopy.data.get_interp_kinematics(bmi3d_data, bmi3d_metadata, datatype='cursor',
-                                                            samplerate=samplerate)
+                    try:
+                        cursor_interp = aopy.data.get_interp_kinematics(bmi3d_data, bmi3d_metadata, datatype='cursor',
+                                                                samplerate=samplerate)
+                    except:
+                        cursor_interp = aopy.data.bmi3d.get_interp_task_data(bmi3d_data, bmi3d_metadata, datatype='cursor',
+                                                                samplerate=samplerate)
+                                            
                     self.eye_coeff,_,_,_ = aopy.preproc.calc_eye_calibration(
                         cursor_interp, samplerate, eye_interp, samplerate, 
                         events['timestamp'], events['code'], return_datapoints=True

--- a/features/eyetracker_features.py
+++ b/features/eyetracker_features.py
@@ -61,6 +61,7 @@ class EyeCalibration(traits.HasTraits):
             raise ValueError(f"Taskid {taskid} not found in database")
         files = entry.get_data_files_dict_absolute()
         print(files)
+        files.pop('ecube') # ignore neural data
         
         self.eye_center = np.zeros((4,))
         _, metadata_hdf = aopy.data.load_bmi3d_hdf_table('', files['hdf'], 'task')


### PR DESCRIPTION
Small fixes of the saccade task:
1. Don't load eCube data ~ not needed and makes starting a task very slow
2. Changed the name of the get_interp_kinematics function
3. Changed chain length so the task also runs with just 1 target (ex. Out_2D)