### PR TITLE
Fix null decoder saving

### DIFF
--- a/built_in_tasks/bmimultitasks.py
+++ b/built_in_tasks/bmimultitasks.py
@@ -306,7 +306,10 @@ class BMIControlMultiMixin(BMILoop, LinearlyDecreasingAssist):
         # Optionally save a new decoder zscored from this task
         if (not self.save_zscore) or (self.saveid is None):
             return
-
+        #Check if null decoder here
+        if hasattr(self.decoder, 'is_null_decoder'):
+            return self.decoder.is_null_decoder
+        
         if not (np.all(self.decoder.mFR == 0) and np.all(self.decoder.sdFR) == 1):
             filename = self.decoder.save()
 

--- a/built_in_tasks/bmimultitasks.py
+++ b/built_in_tasks/bmimultitasks.py
@@ -310,8 +310,8 @@ class BMIControlMultiMixin(BMILoop, LinearlyDecreasingAssist):
         if hasattr(self.decoder, 'is_null_decoder') and self.decoder.is_null_decoder:
             return
         
-            if not (np.all(self.decoder.mFR == 0) and np.all(self.decoder.sdFR == 1)):
-                filename = self.decoder.save()
+        if not (np.all(self.decoder.mFR == 0) and np.all(self.decoder.sdFR == 1)):
+            filename = self.decoder.save()
 
             from db.tracker import dbq
             suffix = f"saved_from_{self.saveid}"

--- a/built_in_tasks/bmimultitasks.py
+++ b/built_in_tasks/bmimultitasks.py
@@ -309,7 +309,7 @@ class BMIControlMultiMixin(BMILoop, LinearlyDecreasingAssist):
         #Check if null decoder here
         if not (hasattr(self.decoder, 'is_null_decoder') and self.decoder.is_null_decoder):
         
-            if not (np.all(self.decoder.mFR == 0) and np.all(self.decoder.sdFR) == 1):
+            if not (np.all(self.decoder.mFR == 0) and np.all(self.decoder.sdFR == 1)):
                 filename = self.decoder.save()
 
                 from db.tracker import dbq

--- a/built_in_tasks/bmimultitasks.py
+++ b/built_in_tasks/bmimultitasks.py
@@ -307,27 +307,27 @@ class BMIControlMultiMixin(BMILoop, LinearlyDecreasingAssist):
         if (not self.save_zscore) or (self.saveid is None):
             return
         #Check if null decoder here
-        if hasattr(self.decoder, 'is_null_decoder'):
-            return self.decoder.is_null_decoder
+        if not (hasattr(self.decoder, 'is_null_decoder') and self.decoder.is_null_decoder):
         
-        if not (np.all(self.decoder.mFR == 0) and np.all(self.decoder.sdFR) == 1):
-            filename = self.decoder.save()
+            if not (np.all(self.decoder.mFR == 0) and np.all(self.decoder.sdFR) == 1):
+                filename = self.decoder.save()
 
-            from db.tracker import dbq
-            suffix = f"saved_from_{self.saveid}"
-            dbq.save_bmi(suffix, self.saveid, filename)
-            return
+                from db.tracker import dbq
+                suffix = f"saved_from_{self.saveid}"
+                dbq.save_bmi(suffix, self.saveid, filename)
+                return
 
-        # This is linear mapping specific - needs updating
-        self.decoder.filt.fix_norm_attr()
-        self.decoder.filt._update_scale_attr()
-        mFR = self.decoder.filt.attr['offset'].copy()
-        sdFR = self.decoder.filt.attr['scale'].copy()
-        n_units = self.decoder.filt.n_units
-        self.decoder.filt.update_norm_attr(offset=np.zeros(n_units), scale=np.ones(n_units))
+            # This is linear mapping specific - needs updating
+            self.decoder.filt.fix_norm_attr()
+            self.decoder.filt._update_scale_attr()
+            mFR = self.decoder.filt.attr['offset'].copy()
+            sdFR = self.decoder.filt.attr['scale'].copy()
+            n_units = self.decoder.filt.n_units
+            self.decoder.filt.update_norm_attr(offset=np.zeros(n_units), scale=np.ones(n_units))
 
-        # The rest should work with any decoder
-        self.decoder.init_zscore(mFR, sdFR)
+            # The rest should work with any decoder
+            self.decoder.init_zscore(mFR, sdFR)
+            
         filename = self.decoder.save()
 
         from db.tracker import dbq

--- a/built_in_tasks/bmimultitasks.py
+++ b/built_in_tasks/bmimultitasks.py
@@ -307,27 +307,28 @@ class BMIControlMultiMixin(BMILoop, LinearlyDecreasingAssist):
         if (not self.save_zscore) or (self.saveid is None):
             return
         #Check if null decoder here
-        if not (hasattr(self.decoder, 'is_null_decoder') and self.decoder.is_null_decoder):
+        if hasattr(self.decoder, 'is_null_decoder') and self.decoder.is_null_decoder:
+            return
         
-            if not (np.all(self.decoder.mFR == 0) and np.all(self.decoder.sdFR) == 1):
-                filename = self.decoder.save()
+        if not (np.all(self.decoder.mFR == 0) and np.all(self.decoder.sdFR) == 1):
+            filename = self.decoder.save()
 
-                from db.tracker import dbq
-                suffix = f"saved_from_{self.saveid}"
-                dbq.save_bmi(suffix, self.saveid, filename)
-                return
+            from db.tracker import dbq
+            suffix = f"saved_from_{self.saveid}"
+            dbq.save_bmi(suffix, self.saveid, filename)
+            return
 
-            # This is linear mapping specific - needs updating
-            self.decoder.filt.fix_norm_attr()
-            self.decoder.filt._update_scale_attr()
-            mFR = self.decoder.filt.attr['offset'].copy()
-            sdFR = self.decoder.filt.attr['scale'].copy()
-            n_units = self.decoder.filt.n_units
-            self.decoder.filt.update_norm_attr(offset=np.zeros(n_units), scale=np.ones(n_units))
+        # This is linear mapping specific - needs updating
+        self.decoder.filt.fix_norm_attr()
+        self.decoder.filt._update_scale_attr()
+        mFR = self.decoder.filt.attr['offset'].copy()
+        sdFR = self.decoder.filt.attr['scale'].copy()
+        n_units = self.decoder.filt.n_units
+        self.decoder.filt.update_norm_attr(offset=np.zeros(n_units), scale=np.ones(n_units))
 
-            # The rest should work with any decoder
-            self.decoder.init_zscore(mFR, sdFR)
-            
+        # The rest should work with any decoder
+        self.decoder.init_zscore(mFR, sdFR)
+        
         filename = self.decoder.save()
 
         from db.tracker import dbq

--- a/built_in_tasks/passivetasks.py
+++ b/built_in_tasks/passivetasks.py
@@ -42,8 +42,9 @@ class EndPostureFeedbackController(BMILoop, traits.HasTraits):
         units = []
         self.decoder = Decoder(filt, units, self.ssm, binlen=1./self.decoder_update_rate)
         self.decoder.n_features = 1
-        #self.decoder.mFR = 0
-        #self.decoder.sdFR = 1  #This should prevent an error from triggering when the decoder is saved
+        print(self.decoder.filt)
+        #This flag is to indicate that it was an assist an not necessary to be saved.
+        self.decoder.is_null_decoder = True
 
     def create_feature_extractor(self):
         self.extractor = DummyExtractor()
@@ -65,8 +66,6 @@ class TargetCaptureVisualFeedbackEyeConstrained(EndPostureFeedbackController, BM
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.most_recent_open_eye = 0
-    
-    
 
     status = dict(
         wait = dict(start_trial="target", start_pause="pause"),

--- a/built_in_tasks/passivetasks.py
+++ b/built_in_tasks/passivetasks.py
@@ -42,8 +42,8 @@ class EndPostureFeedbackController(BMILoop, traits.HasTraits):
         units = []
         self.decoder = Decoder(filt, units, self.ssm, binlen=1./self.decoder_update_rate)
         self.decoder.n_features = 1
-        self.decoder.mFR = 0
-        self.decoder.sdFR = 1  #This should prevent an error from triggering when the decoder is saved
+        #self.decoder.mFR = 0
+        #self.decoder.sdFR = 1  #This should prevent an error from triggering when the decoder is saved
 
     def create_feature_extractor(self):
         self.extractor = DummyExtractor()

--- a/built_in_tasks/passivetasks.py
+++ b/built_in_tasks/passivetasks.py
@@ -42,6 +42,7 @@ class EndPostureFeedbackController(BMILoop, traits.HasTraits):
         units = []
         self.decoder = Decoder(filt, units, self.ssm, binlen=1./self.decoder_update_rate)
         self.decoder.n_features = 1
+        self.decoder.is_null_decoder = True
         
 
     def create_feature_extractor(self):
@@ -64,16 +65,6 @@ class TargetCaptureVisualFeedbackEyeConstrained(EndPostureFeedbackController, BM
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.most_recent_open_eye = 0
-
-    def load_decoder(self):
-        self.ssm = StateSpaceEndptVel2D()
-        A, B, W = self.ssm.get_ssm_matrices()
-        filt = MachineOnlyFilter(A, W)
-        units = []
-        self.decoder = Decoder(filt, units, self.ssm, binlen=1./self.decoder_update_rate)
-        self.decoder.n_features = 1
-        #This flag is to indicate that it was an assist an not necessary to be saved.
-        self.decoder.is_null_decoder = True
 
     status = dict(
         wait = dict(start_trial="target", start_pause="pause"),

--- a/built_in_tasks/passivetasks.py
+++ b/built_in_tasks/passivetasks.py
@@ -42,9 +42,7 @@ class EndPostureFeedbackController(BMILoop, traits.HasTraits):
         units = []
         self.decoder = Decoder(filt, units, self.ssm, binlen=1./self.decoder_update_rate)
         self.decoder.n_features = 1
-        print(self.decoder.filt)
-        #This flag is to indicate that it was an assist an not necessary to be saved.
-        self.decoder.is_null_decoder = True
+        
 
     def create_feature_extractor(self):
         self.extractor = DummyExtractor()
@@ -66,6 +64,16 @@ class TargetCaptureVisualFeedbackEyeConstrained(EndPostureFeedbackController, BM
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.most_recent_open_eye = 0
+
+    def load_decoder(self):
+        self.ssm = StateSpaceEndptVel2D()
+        A, B, W = self.ssm.get_ssm_matrices()
+        filt = MachineOnlyFilter(A, W)
+        units = []
+        self.decoder = Decoder(filt, units, self.ssm, binlen=1./self.decoder_update_rate)
+        self.decoder.n_features = 1
+        #This flag is to indicate that it was an assist an not necessary to be saved.
+        self.decoder.is_null_decoder = True
 
     status = dict(
         wait = dict(start_trial="target", start_pause="pause"),


### PR DESCRIPTION
Final code tweaks for the passive viewing task. Had to add a flag in the decoder saving process to check if there is this null decoder since its missing decoder elements that prevent normal saving and we don't need to save the null decoder.